### PR TITLE
Add stepping support & reversing to ranges

### DIFF
--- a/crates/nu-parser/src/flatten.rs
+++ b/crates/nu-parser/src/flatten.rs
@@ -85,15 +85,19 @@ pub fn flatten_expression(
             }
             output
         }
-        Expr::Range(from, to, op) => {
+        Expr::Range(from, next, to, op) => {
             let mut output = vec![];
             if let Some(f) = from {
                 output.extend(flatten_expression(working_set, f));
             }
+            if let Some(s) = next {
+                output.extend(vec![(op.next_op_span, FlatShape::Operator)]);
+                output.extend(flatten_expression(working_set, s));
+            }
+            output.extend(vec![(op.span, FlatShape::Operator)]);
             if let Some(t) = to {
                 output.extend(flatten_expression(working_set, t));
             }
-            output.extend(vec![(op.span, FlatShape::Operator)]);
             output
         }
         Expr::Bool(_) => {

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -164,6 +164,7 @@ mod range {
                     Expression {
                         expr: Expr::Range(
                             Some(_),
+                            None,
                             Some(_),
                             RangeOperator {
                                 inclusion: RangeInclusion::Inclusive,
@@ -195,9 +196,42 @@ mod range {
                     Expression {
                         expr: Expr::Range(
                             Some(_),
+                            None,
                             Some(_),
                             RangeOperator {
                                 inclusion: RangeInclusion::RightExclusive,
+                                ..
+                            }
+                        ),
+                        ..
+                    }
+                ))
+            }
+            _ => panic!("No match"),
+        }
+    }
+
+    #[test]
+    fn parse_reverse_range() {
+        let engine_state = EngineState::new();
+        let mut working_set = StateWorkingSet::new(&engine_state);
+
+        let (block, err) = parse(&mut working_set, None, b"10..0", true);
+
+        assert!(err.is_none());
+        assert!(block.len() == 1);
+        match &block[0] {
+            Statement::Pipeline(Pipeline { expressions }) => {
+                assert!(expressions.len() == 1);
+                assert!(matches!(
+                    expressions[0],
+                    Expression {
+                        expr: Expr::Range(
+                            Some(_),
+                            None,
+                            Some(_),
+                            RangeOperator {
+                                inclusion: RangeInclusion::Inclusive,
                                 ..
                             }
                         ),
@@ -226,6 +260,7 @@ mod range {
                     Expression {
                         expr: Expr::Range(
                             Some(_),
+                            None,
                             Some(_),
                             RangeOperator {
                                 inclusion: RangeInclusion::RightExclusive,
@@ -257,6 +292,7 @@ mod range {
                     Expression {
                         expr: Expr::Range(
                             Some(_),
+                            None,
                             Some(_),
                             RangeOperator {
                                 inclusion: RangeInclusion::Inclusive,
@@ -288,6 +324,7 @@ mod range {
                     Expression {
                         expr: Expr::Range(
                             Some(_),
+                            None,
                             Some(_),
                             RangeOperator {
                                 inclusion: RangeInclusion::RightExclusive,
@@ -320,6 +357,7 @@ mod range {
                         expr: Expr::Range(
                             Some(_),
                             None,
+                            None,
                             RangeOperator {
                                 inclusion: RangeInclusion::Inclusive,
                                 ..
@@ -350,6 +388,7 @@ mod range {
                     Expression {
                         expr: Expr::Range(
                             Some(_),
+                            None,
                             Some(_),
                             RangeOperator {
                                 inclusion: RangeInclusion::Inclusive,

--- a/crates/nu-protocol/src/ast/expr.rs
+++ b/crates/nu-protocol/src/ast/expr.rs
@@ -7,8 +7,9 @@ pub enum Expr {
     Int(i64),
     Float(f64),
     Range(
-        Option<Box<Expression>>,
-        Option<Box<Expression>>,
+        Option<Box<Expression>>, // from
+        Option<Box<Expression>>, // next value after "from"
+        Option<Box<Expression>>, // to
         RangeOperator,
     ),
     Var(VarId),

--- a/crates/nu-protocol/src/ast/operator.rs
+++ b/crates/nu-protocol/src/ast/operator.rs
@@ -59,6 +59,7 @@ pub enum RangeInclusion {
 pub struct RangeOperator {
     pub inclusion: RangeInclusion,
     pub span: Span,
+    pub next_op_span: Span,
 }
 
 impl Display for RangeOperator {

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -8,7 +8,7 @@ pub use stream::*;
 
 use std::fmt::Debug;
 
-use crate::ast::{PathMember, RangeInclusion};
+use crate::ast::PathMember;
 use crate::{span, BlockId, Span, Type};
 
 use crate::ShellError;
@@ -131,20 +131,10 @@ impl Value {
             Value::Int { val, .. } => val.to_string(),
             Value::Float { val, .. } => val.to_string(),
             Value::Range { val, .. } => {
-                let vals: Vec<i64> = match (&val.from, &val.to) {
-                    (Value::Int { val: from, .. }, Value::Int { val: to, .. }) => {
-                        match val.inclusion {
-                            RangeInclusion::Inclusive => (*from..=*to).collect(),
-                            RangeInclusion::RightExclusive => (*from..*to).collect(),
-                        }
-                    }
-                    _ => Vec::new(),
-                };
-
                 format!(
                     "range: [{}]",
-                    vals.iter()
-                        .map(|x| x.to_string())
+                    val.into_iter()
+                        .map(|x| x.into_string())
                         .collect::<Vec<String>>()
                         .join(", ")
                 )


### PR DESCRIPTION
Follows the following syntax: `<start>..<next-value>..<end>`. In case some of the values is missing, it gets automatically inferred.

Also small refactor to the range iterator.

Examples (these should go into test suite once we have eval tests set up):
* `2..4..8` -> `[2, 4, 6, 8]`
* `2..4..<6` -> `[2, 4, 6]`
* `2..-2..-8` -> `[2, -2, -6]`
* `..2..6` -> parse error but should be equivalent to `0..2..6`
* `2..4..` -> equals to `2..4..100`
* `2..-4..` -> equals to `2..-4..-100`
* `2..6` -> `[2, 3, 4, 5, 6]`
* `2..-2` -> `[2, 1, 0, -1, -2]`
* `2..-2..-2` -> `[2, -2]`

Integer values only for now.