### PR TITLE
Allow parsing left-unbounded range (..10)

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -469,6 +469,15 @@ pub fn parse_call(
     spans: &[Span],
     expand_aliases: bool,
 ) -> (Expression, Option<ParseError>) {
+    // We might be parsing left-unbounded range ("..10")
+    let bytes = working_set.get_span_contents(spans[0]);
+    if let (Some(b'.'), Some(b'.')) = (bytes.get(0), bytes.get(1)) {
+        let (range_expr, range_err) = parse_range(working_set, spans[0]);
+        if range_err.is_none() {
+            return (range_expr, range_err);
+        }
+    }
+
     // assume spans.len() > 0?
     let mut pos = 0;
     let mut shorthand = vec![];

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -469,15 +469,6 @@ pub fn parse_call(
     spans: &[Span],
     expand_aliases: bool,
 ) -> (Expression, Option<ParseError>) {
-    // We might be parsing left-unbounded range ("..10")
-    let bytes = working_set.get_span_contents(spans[0]);
-    if let (Some(b'.'), Some(b'.')) = (bytes.get(0), bytes.get(1)) {
-        let (range_expr, range_err) = parse_range(working_set, spans[0]);
-        if range_err.is_none() {
-            return (range_expr, range_err);
-        }
-    }
-
     // assume spans.len() > 0?
     let mut pos = 0;
     let mut shorthand = vec![];
@@ -601,6 +592,14 @@ pub fn parse_call(
             err,
         )
     } else {
+        // We might be parsing left-unbounded range ("..10")
+        let bytes = working_set.get_span_contents(spans[0]);
+        if let (Some(b'.'), Some(b'.')) = (bytes.get(0), bytes.get(1)) {
+            let (range_expr, range_err) = parse_range(working_set, spans[0]);
+            if range_err.is_none() {
+                return (range_expr, range_err);
+            }
+        }
         parse_external_call(working_set, spans)
     }
 }

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -388,6 +388,7 @@ mod range {
                     Expression {
                         expr: Expr::Range(
                             None,
+                            None,
                             Some(_),
                             RangeOperator {
                                 inclusion: RangeInclusion::Inclusive,

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -372,6 +372,37 @@ mod range {
     }
 
     #[test]
+    fn parse_left_unbounded_range() {
+        let engine_state = EngineState::new();
+        let mut working_set = StateWorkingSet::new(&engine_state);
+
+        let (block, err) = parse(&mut working_set, None, b"..10", true);
+
+        assert!(err.is_none());
+        assert!(block.len() == 1);
+        match &block[0] {
+            Statement::Pipeline(Pipeline { expressions }) => {
+                assert!(expressions.len() == 1);
+                assert!(matches!(
+                    expressions[0],
+                    Expression {
+                        expr: Expr::Range(
+                            None,
+                            Some(_),
+                            RangeOperator {
+                                inclusion: RangeInclusion::Inclusive,
+                                ..
+                            }
+                        ),
+                        ..
+                    }
+                ))
+            }
+            _ => panic!("No match"),
+        }
+    }
+
+    #[test]
     fn parse_negative_range() {
         let engine_state = EngineState::new();
         let mut working_set = StateWorkingSet::new(&engine_state);


### PR DESCRIPTION
This allows parsing `..10` and similar as a left-unbounded range.

Some points:
* Valid path should not be parseable as a valid range because the only case you can have a path separator in a range is this: `0..(4 / 2)..10` which involves spaces. Paths should not have spaces around the separator (I hope?).
* `..` is not allowed to be parsed as a range. Range always needs at least one bound, otherwise it could be easily confused with parent directory.
* With this change, *external* commands with names that could be a valid range (e.g. `..10`) are not allowed since they would parse as a range.
* *Internal* commands named `..10` etc. are allowed.
