### PR TITLE
Block param types

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -19,6 +19,8 @@
 - [x] Iteration (`each`) over tables
 - [x] Row conditions
 - [x] Simple completions
+- [ ] Detecting `$it` currently only looks at top scope but should find any free `$it` in the expression (including subexprs)
+- [ ] Signature needs to make parameters visible in scope before block is parsed
 - [ ] Value serialization
 - [ ] Handling rows with missing columns during a cell path
 - [ ] Error shortcircuit (stopping on first error)

--- a/crates/nu-command/src/benchmark.rs
+++ b/crates/nu-command/src/benchmark.rs
@@ -17,7 +17,11 @@ impl Command for Benchmark {
     }
 
     fn signature(&self) -> nu_protocol::Signature {
-        Signature::build("benchmark").required("block", SyntaxShape::Block, "the block to run")
+        Signature::build("benchmark").required(
+            "block",
+            SyntaxShape::Block(Some(vec![])),
+            "the block to run",
+        )
     }
 
     fn run(

--- a/crates/nu-command/src/def.rs
+++ b/crates/nu-command/src/def.rs
@@ -17,7 +17,11 @@ impl Command for Def {
         Signature::build("def")
             .required("def_name", SyntaxShape::String, "definition name")
             .required("params", SyntaxShape::Signature, "parameters")
-            .required("block", SyntaxShape::Block, "body of the definition")
+            .required(
+                "block",
+                SyntaxShape::Block(Some(vec![])),
+                "body of the definition",
+            )
     }
 
     fn run(

--- a/crates/nu-command/src/do_.rs
+++ b/crates/nu-command/src/do_.rs
@@ -15,7 +15,11 @@ impl Command for Do {
     }
 
     fn signature(&self) -> nu_protocol::Signature {
-        Signature::build("do").required("block", SyntaxShape::Block, "the block to run")
+        Signature::build("do").required(
+            "block",
+            SyntaxShape::Block(Some(vec![])),
+            "the block to run",
+        )
     }
 
     fn run(

--- a/crates/nu-command/src/each.rs
+++ b/crates/nu-command/src/each.rs
@@ -15,7 +15,9 @@ impl Command for Each {
     }
 
     fn signature(&self) -> nu_protocol::Signature {
-        Signature::build("each").required("block", SyntaxShape::Block, "the block to run")
+        Signature::build("each")
+            .required("block", SyntaxShape::Block, "the block to run")
+            .switch("numbered", "iterate with an index", Some('n'))
     }
 
     fn run(
@@ -27,20 +29,42 @@ impl Command for Each {
         let block_id = call.positional[0]
             .as_block()
             .expect("internal error: expected block");
+
+        let numbered = call.has_flag("numbered");
         let context = context.clone();
+        let span = call.head;
 
         match input {
             Value::Range { val, .. } => Ok(Value::Stream {
                 stream: val
                     .into_iter()
-                    .map(move |x| {
+                    .enumerate()
+                    .map(move |(idx, x)| {
                         let engine_state = context.engine_state.borrow();
                         let block = engine_state.get_block(block_id);
 
                         let state = context.enter_scope();
+
                         if let Some(var) = block.signature.get_positional(0) {
                             if let Some(var_id) = &var.var_id {
-                                state.add_var(*var_id, x);
+                                if numbered {
+                                    state.add_var(
+                                        *var_id,
+                                        Value::Record {
+                                            cols: vec!["index".into(), "item".into()],
+                                            vals: vec![
+                                                Value::Int {
+                                                    val: idx as i64,
+                                                    span,
+                                                },
+                                                x,
+                                            ],
+                                            span,
+                                        },
+                                    );
+                                } else {
+                                    state.add_var(*var_id, x);
+                                }
                             }
                         }
 
@@ -55,14 +79,32 @@ impl Command for Each {
             Value::List { vals: val, .. } => Ok(Value::Stream {
                 stream: val
                     .into_iter()
-                    .map(move |x| {
+                    .enumerate()
+                    .map(move |(idx, x)| {
                         let engine_state = context.engine_state.borrow();
                         let block = engine_state.get_block(block_id);
 
                         let state = context.enter_scope();
                         if let Some(var) = block.signature.get_positional(0) {
                             if let Some(var_id) = &var.var_id {
-                                state.add_var(*var_id, x);
+                                if numbered {
+                                    state.add_var(
+                                        *var_id,
+                                        Value::Record {
+                                            cols: vec!["index".into(), "item".into()],
+                                            vals: vec![
+                                                Value::Int {
+                                                    val: idx as i64,
+                                                    span,
+                                                },
+                                                x,
+                                            ],
+                                            span,
+                                        },
+                                    );
+                                } else {
+                                    state.add_var(*var_id, x);
+                                }
                             }
                         }
 
@@ -76,14 +118,32 @@ impl Command for Each {
             }),
             Value::Stream { stream, .. } => Ok(Value::Stream {
                 stream: stream
-                    .map(move |x| {
+                    .enumerate()
+                    .map(move |(idx, x)| {
                         let engine_state = context.engine_state.borrow();
                         let block = engine_state.get_block(block_id);
 
                         let state = context.enter_scope();
                         if let Some(var) = block.signature.get_positional(0) {
                             if let Some(var_id) = &var.var_id {
-                                state.add_var(*var_id, x);
+                                if numbered {
+                                    state.add_var(
+                                        *var_id,
+                                        Value::Record {
+                                            cols: vec!["index".into(), "item".into()],
+                                            vals: vec![
+                                                Value::Int {
+                                                    val: idx as i64,
+                                                    span,
+                                                },
+                                                x,
+                                            ],
+                                            span,
+                                        },
+                                    );
+                                } else {
+                                    state.add_var(*var_id, x);
+                                }
                             }
                         }
 

--- a/crates/nu-command/src/each.rs
+++ b/crates/nu-command/src/each.rs
@@ -16,7 +16,11 @@ impl Command for Each {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("each")
-            .required("block", SyntaxShape::Block, "the block to run")
+            .required(
+                "block",
+                SyntaxShape::Block(Some(vec![SyntaxShape::Any])),
+                "the block to run",
+            )
             .switch("numbered", "iterate with an index", Some('n'))
     }
 

--- a/crates/nu-command/src/for_.rs
+++ b/crates/nu-command/src/for_.rs
@@ -29,7 +29,11 @@ impl Command for For {
                 ),
                 "range of the loop",
             )
-            .required("block", SyntaxShape::Block, "the block to run")
+            .required(
+                "block",
+                SyntaxShape::Block(Some(vec![])),
+                "the block to run",
+            )
     }
 
     fn run(

--- a/crates/nu-command/src/if_.rs
+++ b/crates/nu-command/src/if_.rs
@@ -17,7 +17,7 @@ impl Command for If {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("if")
             .required("cond", SyntaxShape::Expression, "condition")
-            .required("then_block", SyntaxShape::Block, "then block")
+            .required("then_block", SyntaxShape::Block(Some(vec![])), "then block")
             .optional(
                 "else",
                 SyntaxShape::Keyword(b"else".to_vec(), Box::new(SyntaxShape::Expression)),

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1030,17 +1030,20 @@ pub fn parse_variable_expr(
                 None,
             )
         } else {
-            let name = working_set.get_span_contents(span).to_vec();
+            // let name = working_set.get_span_contents(span).to_vec();
             // this seems okay to set it to unknown here, but we should double-check
-            let id = working_set.add_variable(name, Type::Unknown);
-            (
-                Expression {
-                    expr: Expr::Var(id),
-                    span,
-                    ty: Type::Unknown,
-                },
-                None,
-            )
+            //let id = working_set.add_variable(name, Type::Unknown);
+            // (
+            //     Expression {
+            //         expr: Expr::Var(id),
+            //         span,
+            //         ty: Type::Unknown,
+            //     },
+            //     None,
+            // )
+            // } else {
+            (garbage(span), err)
+            // }
         }
     } else {
         (garbage(span), err)
@@ -1995,6 +1998,7 @@ pub fn parse_block_expression(
         output.signature = signature;
     } else if let Some(last) = working_set.delta.scope.last() {
         // FIXME: this only supports the top $it. Instead, we should look for a free $it in the expression.
+
         if let Some(var_id) = last.get_var(b"$it") {
             let mut signature = Signature::new("");
             signature.required_positional.push(PositionalArg {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1992,6 +1992,7 @@ pub fn parse_block_expression(
     if let Some(signature) = signature {
         output.signature = signature;
     } else if let Some(last) = working_set.delta.scope.last() {
+        // FIXME: this only supports the top $it. Instead, we should look for a free $it in the expression.
         if let Some(var_id) = last.get_var(b"$it") {
             let mut signature = Signature::new("");
             signature.required_positional.push(PositionalArg {

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -20,6 +20,7 @@ pub fn math_result_type(
     op: &mut Expression,
     rhs: &mut Expression,
 ) -> (Type, Option<ParseError>) {
+    //println!("checking: {:?} {:?} {:?}", lhs, op, rhs);
     match &op.expr {
         Expr::Operator(operator) => match operator {
             Operator::Plus => match (&lhs.ty, &rhs.ty) {

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -2,9 +2,42 @@ use nu_parser::ParseError;
 use nu_parser::*;
 use nu_protocol::{
     ast::{Expr, Expression, Pipeline, Statement},
-    engine::{EngineState, StateWorkingSet},
+    engine::{Command, EngineState, StateWorkingSet},
     Signature, SyntaxShape,
 };
+
+#[cfg(test)]
+pub struct Let;
+
+#[cfg(test)]
+impl Command for Let {
+    fn name(&self) -> &str {
+        "let"
+    }
+
+    fn usage(&self) -> &str {
+        "Create a variable and give it a value."
+    }
+
+    fn signature(&self) -> nu_protocol::Signature {
+        Signature::build("let")
+            .required("var_name", SyntaxShape::VarWithOptType, "variable name")
+            .required(
+                "initial_value",
+                SyntaxShape::Keyword(b"=".to_vec(), Box::new(SyntaxShape::Expression)),
+                "equals sign followed by value",
+            )
+    }
+
+    fn run(
+        &self,
+        _context: &nu_protocol::engine::EvaluationContext,
+        _call: &nu_protocol::ast::Call,
+        _input: nu_protocol::Value,
+    ) -> Result<nu_protocol::Value, nu_protocol::ShellError> {
+        todo!()
+    }
+}
 
 #[test]
 pub fn parse_int() {
@@ -280,6 +313,8 @@ mod range {
         let engine_state = EngineState::new();
         let mut working_set = StateWorkingSet::new(&engine_state);
 
+        working_set.add_decl(Box::new(Let));
+
         let (block, err) = parse(&mut working_set, None, b"let a = 2; $a..10", true);
 
         assert!(err.is_none());
@@ -311,6 +346,8 @@ mod range {
     fn parse_subexpression_variable_range() {
         let engine_state = EngineState::new();
         let mut working_set = StateWorkingSet::new(&engine_state);
+
+        working_set.add_decl(Box::new(Let));
 
         let (block, err) = parse(&mut working_set, None, b"let a = 2; $a..<($a + 10)", true);
 

--- a/crates/nu-protocol/src/ast/call.rs
+++ b/crates/nu-protocol/src/ast/call.rs
@@ -25,4 +25,14 @@ impl Call {
             named: vec![],
         }
     }
+
+    pub fn has_flag(&self, flag_name: &str) -> bool {
+        for name in &self.named {
+            if flag_name == name.0 {
+                return true;
+            }
+        }
+
+        false
+    }
 }

--- a/crates/nu-protocol/src/syntax_shape.rs
+++ b/crates/nu-protocol/src/syntax_shape.rs
@@ -34,7 +34,7 @@ pub enum SyntaxShape {
     GlobPattern,
 
     /// A block is allowed, eg `{start this thing}`
-    Block(Vec<(Vec<u8>, SyntaxShape)>),
+    Block(Option<Vec<SyntaxShape>>),
 
     /// A table is allowed, eg `[[first, second]; [1, 2]]`
     Table,
@@ -75,7 +75,7 @@ impl SyntaxShape {
     pub fn to_type(&self) -> Type {
         match self {
             SyntaxShape::Any => Type::Unknown,
-            SyntaxShape::Block => Type::Block,
+            SyntaxShape::Block(_) => Type::Block,
             SyntaxShape::CellPath => Type::Unknown,
             SyntaxShape::Duration => Type::Duration,
             SyntaxShape::Expression => Type::Unknown,

--- a/crates/nu-protocol/src/syntax_shape.rs
+++ b/crates/nu-protocol/src/syntax_shape.rs
@@ -34,7 +34,7 @@ pub enum SyntaxShape {
     GlobPattern,
 
     /// A block is allowed, eg `{start this thing}`
-    Block,
+    Block(Vec<(Vec<u8>, SyntaxShape)>),
 
     /// A table is allowed, eg `[[first, second]; [1, 2]]`
     Table,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -308,3 +308,11 @@ fn row_condition2() -> TestResult {
         "1",
     )
 }
+
+#[test]
+fn better_block_types() -> TestResult {
+    run_test(
+        r#"([1, 2, 3] | each -n { $"($it.index) is ($it.item)" }).1"#,
+        "1 is 2",
+    )
+}


### PR DESCRIPTION
This adds block param shapes to block shapes (not yet as part of syntax). This allows commands to say whether or not they expect a block that takes a param.

This makes it easier to know when to imply that there is an `$it` in the param that's unnamed or not, as some commands will want this and others won't.