### PR TITLE
use miette's new panic hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61f2b7f93d2c7d2b08263acaa4a363b3e276806c68af6134c44f523bf1aacd"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,6 +67,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "backtrace"
+version = "0.3.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a905d892734eea339e896738c14b9afce22b5318f64b951e70bf3844419b01"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,6 +97,12 @@ dependencies = [
  "memchr",
  "regex-automata",
 ]
+
+[[package]]
+name = "cc"
+version = "1.0.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
 
 [[package]]
 name = "cfg-if"
@@ -210,6 +246,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,9 +339,10 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 [[package]]
 name = "miette"
 version = "3.0.1-alpha.0"
-source = "git+https://github.com/zkat/miette?branch=release/3.0.0#338c885a305035fc21f63e3566131af5befa14b3"
+source = "git+https://github.com/zkat/miette?rev=183ecb9#183ecb9b78a1c22d832e979db5054dcac36d8b7a"
 dependencies = [
  "atty",
+ "backtrace",
  "ci_info",
  "itertools",
  "miette-derive",
@@ -317,11 +360,21 @@ dependencies = [
 [[package]]
 name = "miette-derive"
 version = "3.0.0-alpha.0"
-source = "git+https://github.com/zkat/miette?branch=release/3.0.0#338c885a305035fc21f63e3566131af5befa14b3"
+source = "git+https://github.com/zkat/miette?rev=183ecb9#183ecb9b78a1c22d832e979db5054dcac36d8b7a"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+dependencies = [
+ "adler",
+ "autocfg",
 ]
 
 [[package]]
@@ -440,6 +493,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "object"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39f37e50073ccad23b6d09bcb5b263f4e76d3bb6038e4a3c08e52162ffa8abc2"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -650,6 +712,12 @@ checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "scopeguard"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ nu-engine = { path="./crates/nu-engine" }
 nu-parser = { path="./crates/nu-parser" }
 nu-protocol = { path = "./crates/nu-protocol" }
 nu-table = { path = "./crates/nu-table" }
-miette = { git = "https://github.com/zkat/miette", branch = "release/3.0.0" }
+miette = { git = "https://github.com/zkat/miette", rev = "183ecb9" }
+# miette = { path = "../miette" }
 # mimalloc = { version = "*", default-features = false }
 
 [dev-dependencies]

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2018"
 nu-engine = { path = "../nu-engine" }
 nu-parser = { path = "../nu-parser" }
 nu-protocol = { path = "../nu-protocol" }
-miette = { git = "https://github.com/zkat/miette", branch = "release/3.0.0", features = ["fancy"] }
+miette = { git = "https://github.com/zkat/miette", rev = "183ecb9", features = ["fancy"] }
+# miette = { path = "../../../miette", features = ["fancy"] }
 thiserror = "1.0.29"
 nu-ansi-term = "0.36.0"
 reedline = { git = "https://github.com/jntrnr/reedline", branch = "main" }

--- a/crates/nu-parser/Cargo.toml
+++ b/crates/nu-parser/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-miette = { git = "https://github.com/zkat/miette", branch = "release/3.0.0" }
+miette = { git = "https://github.com/zkat/miette", rev = "183ecb9" }
+# miette = { path = "../../../miette" }
 thiserror = "1.0.29"
 nu-protocol = { path = "../nu-protocol"}

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2018"
 
 [dependencies]
 thiserror = "1.0.29"
-miette = { git = "https://github.com/zkat/miette", branch = "release/3.0.0" }
+miette = { git = "https://github.com/zkat/miette", rev = "183ecb9" }
+# miette = { path = "../../../miette" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,8 @@ use reedline::DefaultCompletionActionHandler;
 mod tests;
 
 fn main() -> Result<()> {
+    miette::set_panic_hook();
+
     let engine_state = create_default_context();
 
     if let Some(path) = std::env::args().nth(1) {


### PR DESCRIPTION
This also changes the style of depending on miette to target specific commits. Not only will this make things more predictable, but also you won't have to do some weird `cargo update --workspace -p miette` any time you want the latest miette.