### PR TITLE
Better print out for stream output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
+checksum = "716d3d89f35ac6a34fd0eed635395f4c3b76fa889338a4632e5231a8684216bd"
 dependencies = [
  "cfg-if",
 ]
@@ -625,8 +625,8 @@ dependencies = [
 
 [[package]]
 name = "reedline"
-version = "0.1.0"
-source = "git+https://github.com/jntrnr/reedline?branch=main#22fc31c68d1da6a41a93b5cfa901143b4eca4051"
+version = "0.2.0"
+source = "git+https://github.com/jntrnr/reedline?branch=main#93c2146fcf4257c40426bc2f0c6903d4115caaf1"
 dependencies = [
  "chrono",
  "crossterm",
@@ -772,9 +772,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.76"
+version = "1.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
+checksum = "5239bc68e0fef57495900cfea4e8dc75596d9a319d7e16b1e0a440d24e6fe0a0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/nu-command/src/run_external.rs
+++ b/crates/nu-command/src/run_external.rs
@@ -154,7 +154,7 @@ impl<'call, 'contex> ExternalCommand<'call, 'contex> {
                 // If this external is not the last expression, then its output is piped to a channel
                 // and we create a ValueStream that can be consumed
                 let value = if !self.last_expression {
-                    let (tx, rx) = mpsc::sync_channel(0);
+                    let (tx, rx) = mpsc::channel();
                     let stdout = child.stdout.take().ok_or_else(|| {
                         ShellError::ExternalCommand(
                             "Error taking stdout from external".to_string(),

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -69,4 +69,8 @@ pub enum ShellError {
     #[error("External command")]
     #[diagnostic(code(nu::shell::external_command), url(docsrs))]
     ExternalCommand(String, #[label("{0}")] Span),
+
+    #[error("Unsupported input")]
+    #[diagnostic(code(nu::shell::unsupported_input), url(docsrs))]
+    UnsupportedInput(String, #[label("{0}")] Span),
 }

--- a/crates/nu-protocol/src/value/stream.rs
+++ b/crates/nu-protocol/src/value/stream.rs
@@ -6,9 +6,12 @@ pub struct ValueStream(pub Rc<RefCell<dyn Iterator<Item = Value>>>);
 
 impl ValueStream {
     pub fn into_string(self) -> String {
-        self.map(|x: Value| x.into_string())
-            .collect::<Vec<String>>()
-            .join("\n")
+        format!(
+            "[{}]",
+            self.map(|x: Value| x.into_string())
+                .collect::<Vec<String>>()
+                .join(", ")
+        )
     }
 
     pub fn from_stream(input: impl Iterator<Item = Value> + 'static) -> ValueStream {

--- a/crates/nu-protocol/src/value/stream.rs
+++ b/crates/nu-protocol/src/value/stream.rs
@@ -6,12 +6,9 @@ pub struct ValueStream(pub Rc<RefCell<dyn Iterator<Item = Value>>>);
 
 impl ValueStream {
     pub fn into_string(self) -> String {
-        format!(
-            "[{}]",
-            self.map(|x: Value| x.into_string())
-                .collect::<Vec<String>>()
-                .join(", ")
-        )
+        self.map(|x: Value| x.into_string())
+            .collect::<Vec<String>>()
+            .join("\n")
     }
 
     pub fn from_stream(input: impl Iterator<Item = Value> + 'static) -> ValueStream {


### PR DESCRIPTION
Corrected bug with channel. Using `sync_channel` was blocking some external commands, like `rg`.

Things that still need correction:
- When using `cat` (probably only windows) the prompt gets mangled and it can only be seen as bytes. It goes back to normal after typing something and pressing enter
![image](https://user-images.githubusercontent.com/6942205/134671548-d049b05f-fbe6-4fa4-a9ac-184d3173a0ec.png)

- Python commands are not sent to stdout. If we send `python -c "print('hello')"` the output is missed. However we can enter a python shell without problem

- The use of `^` for marking and external command. Now `git` cannot be used because there is a git command in engine-q