### PR TITLE
Table as string output

### DIFF
--- a/crates/nu-command/src/build_string.rs
+++ b/crates/nu-command/src/build_string.rs
@@ -1,7 +1,7 @@
 use nu_engine::eval_expression;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EvaluationContext};
-use nu_protocol::{Signature, SyntaxShape, Value};
+use nu_protocol::{ShellError, Signature, SyntaxShape, Value};
 
 pub struct BuildString;
 
@@ -24,13 +24,12 @@ impl Command for BuildString {
         call: &Call,
         _input: Value,
     ) -> Result<nu_protocol::Value, nu_protocol::ShellError> {
-        let mut output = vec![];
+        let output = call
+            .positional
+            .iter()
+            .map(|expr| eval_expression(context, expr).map(|val| val.into_string()))
+            .collect::<Result<Vec<String>, ShellError>>()?;
 
-        for expr in &call.positional {
-            let val = eval_expression(context, expr)?;
-
-            output.push(val.into_string());
-        }
         Ok(Value::String {
             val: output.join(""),
             span: call.head,

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -67,6 +67,8 @@ pub fn create_default_context() -> Rc<RefCell<EngineState>> {
         working_set.add_decl(sig.predeclare());
         let sig = Signature::build("stack");
         working_set.add_decl(sig.predeclare());
+        let sig = Signature::build("contents");
+        working_set.add_decl(sig.predeclare());
 
         working_set.render()
     };

--- a/crates/nu-command/src/lines.rs
+++ b/crates/nu-command/src/lines.rs
@@ -62,7 +62,7 @@ impl Command for Lines {
                                 .filter_map(|s| {
                                     if !s.is_empty() {
                                         Some(Value::String {
-                                            val: s.into(),
+                                            val: s.trim().into(),
                                             span,
                                         })
                                     } else {

--- a/crates/nu-command/src/run_external.rs
+++ b/crates/nu-command/src/run_external.rs
@@ -117,7 +117,6 @@ impl<'call, 'contex> ExternalCommand<'call, 'contex> {
             Ok(mut child) => {
                 // if there is a string or a stream, that is sent to the pipe std
                 match input {
-                    Value::Nothing { span: _ } => (),
                     Value::String { val, span: _ } => {
                         if let Some(mut stdin_write) = child.stdin.take() {
                             self.write_to_stdin(&mut stdin_write, val.as_bytes())?
@@ -143,12 +142,7 @@ impl<'call, 'contex> ExternalCommand<'call, 'contex> {
                             }
                         }
                     }
-                    _ => {
-                        return Err(ShellError::ExternalCommand(
-                            "Input is not string or binary".to_string(),
-                            self.name.span,
-                        ))
-                    }
+                    _ => (),
                 }
 
                 // If this external is not the last expression, then its output is piped to a channel

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -113,6 +113,11 @@ impl EngineState {
         }
     }
 
+    pub fn print_contents(&self) {
+        let string = String::from_utf8_lossy(&self.file_contents);
+        println!("{}", string);
+    }
+
     pub fn find_decl(&self, name: &[u8]) -> Option<DeclId> {
         for scope in self.scope.iter().rev() {
             if let Some(decl_id) = scope.decls.get(name) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use nu_parser::parse;
 use nu_protocol::{
     ast::Call,
     engine::{EngineState, EvaluationContext, StateWorkingSet},
-    Value,
+    ShellError, Value,
 };
 use reedline::DefaultCompletionActionHandler;
 
@@ -128,28 +128,7 @@ fn main() -> Result<()> {
                     };
 
                     match eval_block(&state, &block, Value::nothing()) {
-                        Ok(value) => {
-                            // If the table function is in the declarations, then we can use it
-                            // to create the table value that will be printed in the terminal
-                            let engine_state = engine_state.borrow();
-                            let output = match engine_state.find_decl("table".as_bytes()) {
-                                Some(decl_id) => {
-                                    let table = engine_state.get_decl(decl_id).run(
-                                        &state,
-                                        &Call::new(),
-                                        value,
-                                    )?;
-                                    table.into_string()
-                                }
-                                None => value.into_string(),
-                            };
-                            let stdout = std::io::stdout();
-
-                            match stdout.lock().write_all(output.as_bytes()) {
-                                Ok(_) => (),
-                                Err(err) => eprintln!("{}", err),
-                            };
-                        }
+                        Ok(value) => print_value(value, &state)?,
                         Err(err) => {
                             let engine_state = engine_state.borrow();
                             let working_set = StateWorkingSet::new(&*engine_state);
@@ -178,4 +157,27 @@ fn main() -> Result<()> {
 
         Ok(())
     }
+}
+
+fn print_value(value: Value, state: &EvaluationContext) -> Result<(), ShellError> {
+    // If the table function is in the declarations, then we can use it
+    // to create the table value that will be printed in the terminal
+    let engine_state = state.engine_state.borrow();
+    let output = match engine_state.find_decl("table".as_bytes()) {
+        Some(decl_id) => {
+            let table = engine_state
+                .get_decl(decl_id)
+                .run(&state, &Call::new(), value)?;
+            table.into_string()
+        }
+        None => value.into_string(),
+    };
+    let stdout = std::io::stdout();
+
+    match stdout.lock().write_all(output.as_bytes()) {
+        Ok(_) => (),
+        Err(err) => eprintln!("{}", err),
+    };
+
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -167,7 +167,7 @@ fn print_value(value: Value, state: &EvaluationContext) -> Result<(), ShellError
         Some(decl_id) => {
             let table = engine_state
                 .get_decl(decl_id)
-                .run(&state, &Call::new(), value)?;
+                .run(state, &Call::new(), value)?;
             table.into_string()
         }
         None => value.into_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,6 +102,9 @@ fn main() -> Result<()> {
                     } else if s.trim() == "stack" {
                         stack.print_stack();
                         continue;
+                    } else if s.trim() == "contents" {
+                        engine_state.borrow().print_contents();
+                        continue;
                     }
 
                     let (block, delta) = {

--- a/src/main.rs
+++ b/src/main.rs
@@ -134,9 +134,11 @@ fn main() -> Result<()> {
                             let engine_state = engine_state.borrow();
                             let output = match engine_state.find_decl("table".as_bytes()) {
                                 Some(decl_id) => {
-                                    let command = engine_state.get_decl(decl_id);
-
-                                    let table = command.run(&state, &Call::new(), value)?;
+                                    let table = engine_state.get_decl(decl_id).run(
+                                        &state,
+                                        &Call::new(),
+                                        value,
+                                    )?;
                                     table.into_string()
                                 }
                                 None => value.into_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+use std::io::Write;
+
 use miette::{IntoDiagnostic, Result};
 use nu_cli::{report_error, NuCompleter, NuHighlighter, NuValidator};
 use nu_command::create_default_context;
@@ -139,7 +141,12 @@ fn main() -> Result<()> {
                                 }
                                 None => value.into_string(),
                             };
-                            println!("{}", output);
+                            let stdout = std::io::stdout();
+
+                            match stdout.lock().write_all(output.as_bytes()) {
+                                Ok(_) => (),
+                                Err(err) => eprintln!("{}", err),
+                            };
                         }
                         Err(err) => {
                             let engine_state = engine_state.borrow();


### PR DESCRIPTION
If the `Table` command is found in the command declarations, then it is used to format the output calculated from the evaluation stage.
![image](https://user-images.githubusercontent.com/6942205/134775580-6d2e0110-5371-467c-b675-00ad7e6569f5.png)

Note: Only evaluations happening in interactive move are printed as tables. Files still maintain the old format to avoid errors with the tests