### PR TITLE
Primitive module implementation

### DIFF
--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -7,7 +7,7 @@ use nu_protocol::{
 
 use crate::{
     where_::Where, Alias, Benchmark, BuildString, Def, Do, Each, External, For, Git, GitCheckout,
-    If, Length, Let, LetEnv, Lines, ListGitBranches, Ls, Table,
+    If, Length, Let, LetEnv, Lines, ListGitBranches, Ls, Module, Table,
 };
 
 pub fn create_default_context() -> Rc<RefCell<EngineState>> {
@@ -45,6 +45,8 @@ pub fn create_default_context() -> Rc<RefCell<EngineState>> {
         working_set.add_decl(Box::new(Length));
 
         working_set.add_decl(Box::new(Ls));
+
+        working_set.add_decl(Box::new(Module));
 
         working_set.add_decl(Box::new(Table));
 

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -7,7 +7,7 @@ use nu_protocol::{
 
 use crate::{
     where_::Where, Alias, Benchmark, BuildString, Def, Do, Each, External, For, Git, GitCheckout,
-    If, Length, Let, LetEnv, Lines, ListGitBranches, Ls, Module, Table,
+    If, Length, Let, LetEnv, Lines, ListGitBranches, Ls, Module, Table, Use,
 };
 
 pub fn create_default_context() -> Rc<RefCell<EngineState>> {
@@ -47,6 +47,8 @@ pub fn create_default_context() -> Rc<RefCell<EngineState>> {
         working_set.add_decl(Box::new(Ls));
 
         working_set.add_decl(Box::new(Module));
+
+        working_set.add_decl(Box::new(Use));
 
         working_set.add_decl(Box::new(Table));
 

--- a/crates/nu-command/src/lib.rs
+++ b/crates/nu-command/src/lib.rs
@@ -16,6 +16,7 @@ mod lines;
 mod list_git_branches;
 mod ls;
 mod run_external;
+mod module;
 mod table;
 mod where_;
 
@@ -37,4 +38,5 @@ pub use lines::Lines;
 pub use list_git_branches::ListGitBranches;
 pub use ls::Ls;
 pub use run_external::External;
+pub use module::Module;
 pub use table::Table;

--- a/crates/nu-command/src/lib.rs
+++ b/crates/nu-command/src/lib.rs
@@ -15,8 +15,8 @@ mod let_env;
 mod lines;
 mod list_git_branches;
 mod ls;
-mod run_external;
 mod module;
+mod run_external;
 mod table;
 mod where_;
 
@@ -37,6 +37,6 @@ pub use let_env::LetEnv;
 pub use lines::Lines;
 pub use list_git_branches::ListGitBranches;
 pub use ls::Ls;
-pub use run_external::External;
 pub use module::Module;
+pub use run_external::External;
 pub use table::Table;

--- a/crates/nu-command/src/lib.rs
+++ b/crates/nu-command/src/lib.rs
@@ -18,6 +18,7 @@ mod ls;
 mod module;
 mod run_external;
 mod table;
+mod use_;
 mod where_;
 
 pub use alias::Alias;
@@ -40,3 +41,4 @@ pub use ls::Ls;
 pub use module::Module;
 pub use run_external::External;
 pub use table::Table;
+pub use use_::Use;

--- a/crates/nu-command/src/module.rs
+++ b/crates/nu-command/src/module.rs
@@ -1,0 +1,34 @@
+use nu_protocol::ast::Call;
+use nu_protocol::engine::{Command, EvaluationContext};
+use nu_protocol::{Signature, SyntaxShape, Value};
+
+pub struct Module;
+
+impl Command for Module {
+    fn name(&self) -> &str {
+        "module"
+    }
+
+    fn usage(&self) -> &str {
+        "Define a custom module"
+    }
+
+    fn signature(&self) -> nu_protocol::Signature {
+        Signature::build("module")
+            .required("module_name", SyntaxShape::String, "module name")
+            .required(
+                "block",
+                SyntaxShape::Block(Some(vec![])),
+                "body of the module",
+            )
+    }
+
+    fn run(
+        &self,
+        _context: &EvaluationContext,
+        call: &Call,
+        _input: Value,
+    ) -> Result<nu_protocol::Value, nu_protocol::ShellError> {
+        Ok(Value::Nothing { span: call.head })
+    }
+}

--- a/crates/nu-command/src/use_.rs
+++ b/crates/nu-command/src/use_.rs
@@ -14,8 +14,7 @@ impl Command for Use {
     }
 
     fn signature(&self) -> nu_protocol::Signature {
-        Signature::build("use")
-            .required("module_name", SyntaxShape::String, "module name")
+        Signature::build("use").required("module_name", SyntaxShape::String, "module name")
     }
 
     fn run(

--- a/crates/nu-command/src/use_.rs
+++ b/crates/nu-command/src/use_.rs
@@ -1,0 +1,29 @@
+use nu_protocol::ast::Call;
+use nu_protocol::engine::{Command, EvaluationContext};
+use nu_protocol::{Signature, SyntaxShape, Value};
+
+pub struct Use;
+
+impl Command for Use {
+    fn name(&self) -> &str {
+        "use"
+    }
+
+    fn usage(&self) -> &str {
+        "Use definitions from a module"
+    }
+
+    fn signature(&self) -> nu_protocol::Signature {
+        Signature::build("use")
+            .required("module_name", SyntaxShape::String, "module name")
+    }
+
+    fn run(
+        &self,
+        _context: &EvaluationContext,
+        call: &Call,
+        _input: Value,
+    ) -> Result<nu_protocol::Value, nu_protocol::ShellError> {
+        Ok(Value::Nothing { span: call.head })
+    }
+}

--- a/crates/nu-parser/src/errors.rs
+++ b/crates/nu-parser/src/errors.rs
@@ -65,6 +65,10 @@ pub enum ParseError {
     #[diagnostic(code(nu::parser::variable_not_found), url(docsrs))]
     VariableNotFound(#[label = "variable not found"] Span),
 
+    #[error("Module not found.")]
+    #[diagnostic(code(nu::parser::module_not_found), url(docsrs))]
+    ModuleNotFound(#[label = "module not found"] Span),
+
     #[error("Unknown command.")]
     #[diagnostic(
         code(nu::parser::unknown_command),

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2747,13 +2747,34 @@ pub fn parse_module(
 
         working_set.exit_scope();
 
-        // WIP error:
+        let block_id = working_set.add_block(block);
+
+        let block_expr = Expression {
+            expr: Expr::Block(block_id),
+            span: block_span,
+            ty: Type::Block,
+            custom_completion: None,
+        };
+
+        let module_decl_id = working_set
+            .find_decl(b"module")
+            .expect("internal error: missing module command");
+
+        let call = Box::new(Call {
+            head: spans[0],
+            decl_id: module_decl_id,
+            positional: vec![name_expr, block_expr],
+            named: vec![],
+        });
+
         (
-            garbage_statement(spans),
-            Some(ParseError::UnknownState(
-                "This is OK module".into(),
-                span(spans),
-            )),
+            Statement::Pipeline(Pipeline::from_vec(vec![Expression {
+                expr: Expr::Call(call),
+                span: span(spans),
+                ty: Type::Unknown,
+                custom_completion: None,
+            }])),
+            error,
         )
     } else {
         (

--- a/crates/nu-protocol/src/ast/block.rs
+++ b/crates/nu-protocol/src/ast/block.rs
@@ -1,6 +1,6 @@
 use std::ops::{Index, IndexMut};
 
-use crate::{Signature, DeclId};
+use crate::{DeclId, Signature};
 
 use super::Statement;
 

--- a/crates/nu-protocol/src/ast/block.rs
+++ b/crates/nu-protocol/src/ast/block.rs
@@ -1,6 +1,6 @@
 use std::ops::{Index, IndexMut};
 
-use crate::Signature;
+use crate::{Signature, DeclId};
 
 use super::Statement;
 
@@ -8,7 +8,7 @@ use super::Statement;
 pub struct Block {
     pub signature: Box<Signature>,
     pub stmts: Vec<Statement>,
-    pub exports: Vec<Vec<u8>>, // Assuming just defs for now
+    pub exports: Vec<(Vec<u8>, DeclId)>, // Assuming just defs for now
 }
 
 impl Block {
@@ -50,7 +50,7 @@ impl Block {
         }
     }
 
-    pub fn with_exports(self, exports: Vec<Vec<u8>>) -> Self {
+    pub fn with_exports(self, exports: Vec<(Vec<u8>, DeclId)>) -> Self {
         Self {
             signature: self.signature,
             stmts: self.stmts,

--- a/crates/nu-protocol/src/ast/block.rs
+++ b/crates/nu-protocol/src/ast/block.rs
@@ -8,6 +8,7 @@ use super::Statement;
 pub struct Block {
     pub signature: Box<Signature>,
     pub stmts: Vec<Statement>,
+    pub exports: Vec<Vec<u8>>, // Assuming just defs for now
 }
 
 impl Block {
@@ -45,6 +46,15 @@ impl Block {
         Self {
             signature: Box::new(Signature::new("")),
             stmts: vec![],
+            exports: vec![],
+        }
+    }
+
+    pub fn with_exports(self, exports: Vec<Vec<u8>>) -> Self {
+        Self {
+            signature: self.signature,
+            stmts: self.stmts,
+            exports,
         }
     }
 }
@@ -57,6 +67,7 @@ where
         Self {
             signature: Box::new(Signature::new("")),
             stmts: stmts.collect(),
+            exports: vec![],
         }
     }
 }

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -78,6 +78,9 @@ impl EngineState {
             for item in first.aliases.into_iter() {
                 last.aliases.insert(item.0, item.1);
             }
+            for item in first.modules.into_iter() {
+                last.modules.insert(item.0, item.1);
+            }
         }
     }
 
@@ -388,6 +391,22 @@ impl<'a> StateWorkingSet<'a> {
         for scope in self.permanent_state.scope.iter().rev() {
             if let Some(decl_id) = scope.decls.get(name) {
                 return Some(*decl_id);
+            }
+        }
+
+        None
+    }
+
+    pub fn find_module(&self, name: &[u8]) -> Option<BlockId> {
+        for scope in self.delta.scope.iter().rev() {
+            if let Some(block_id) = scope.modules.get(name) {
+                return Some(*block_id);
+            }
+        }
+
+        for scope in self.permanent_state.scope.iter().rev() {
+            if let Some(block_id) = scope.modules.get(name) {
+                return Some(*block_id);
             }
         }
 

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -312,6 +312,20 @@ impl<'a> StateWorkingSet<'a> {
         block_id
     }
 
+    pub fn activate_overlay(&mut self, overlay: Vec<(Vec<u8>, DeclId)>) {
+        // TODO: This will overwrite all existing definitions in a scope. When we add deactivate,
+        // we need to re-think how make it recoverable.
+        let scope_frame = self
+            .delta
+            .scope
+            .last_mut()
+            .expect("internal error: missing required scope frame");
+
+        for (name, decl_id) in overlay {
+            scope_frame.decls.insert(name, decl_id);
+        }
+    }
+
     pub fn next_span_start(&self) -> usize {
         self.permanent_state.next_span_start() + self.delta.file_contents.len()
     }

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -17,6 +17,7 @@ pub struct ScopeFrame {
     vars: HashMap<Vec<u8>, VarId>,
     decls: HashMap<Vec<u8>, DeclId>,
     aliases: HashMap<Vec<u8>, Vec<Span>>,
+    modules: HashMap<Vec<u8>, BlockId>,
 }
 
 impl ScopeFrame {
@@ -25,6 +26,7 @@ impl ScopeFrame {
             vars: HashMap::new(),
             decls: HashMap::new(),
             aliases: HashMap::new(),
+            modules: HashMap::new(),
         }
     }
 
@@ -288,6 +290,23 @@ impl<'a> StateWorkingSet<'a> {
         self.delta.blocks.push(block);
 
         self.num_blocks() - 1
+    }
+
+    pub fn add_module(&mut self, name: &str, block: Block) -> BlockId {
+        let name = name.as_bytes().to_vec();
+
+        self.delta.blocks.push(block);
+        let block_id = self.num_blocks() - 1;
+
+        let scope_frame = self
+            .delta
+            .scope
+            .last_mut()
+            .expect("internal error: missing required scope frame");
+
+        scope_frame.modules.insert(name, block_id);
+
+        block_id
     }
 
     pub fn next_span_start(&self) -> usize {


### PR DESCRIPTION
Introduces `module` and `use` keywords to define a module and import custom commands from it.

Current limitations:
* Currently, only custom commands are supported for export
* Also, all defs within a module are exported, there is no selective export yet, neither are the definitions hidden behind namespace
* `module` also closes over its parent scope which we probably want to disallow
  * This could be handled by the same mechanic as deactivate: When entering a module scope, deactivate everything
* No module from file yet
* No deactivate yet
* No nested modules yet
* Modules are implemented as Blocks which expose what definitions are to be exported. However, we do not use the underlying Block anywhere at all, so we might change Module to be just a list of exportables.
  * If we make `use` to also evaluate the module, we would probably need the block