### PR TITLE
Disable crossterm raw mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,6 +265,7 @@ name = "engine-q"
 version = "0.1.0"
 dependencies = [
  "assert_cmd",
+ "crossterm",
  "miette",
  "nu-cli",
  "nu-command",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = ["crates/nu-cli", "crates/nu-engine", "crates/nu-parser", "crates/nu-c
 
 [dependencies]
 reedline = { git = "https://github.com/jntrnr/reedline", branch = "main" }
+crossterm = "0.21.*"
 nu-cli = { path="./crates/nu-cli" }
 nu-command = { path="./crates/nu-command" }
 nu-engine = { path="./crates/nu-engine" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,11 @@ mod tests;
 
 fn main() -> Result<()> {
     miette::set_panic_hook();
+    let miette_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |x| {
+        crossterm::terminal::disable_raw_mode().unwrap();
+        miette_hook(x);
+    }));
 
     let engine_state = create_default_context();
 


### PR DESCRIPTION
Without this change, the output of panic messages by miette would ignore
newlines and become unreadable.