### PR TITLE
Prompt with env variable

### DIFF
--- a/crates/nu-cli/src/lib.rs
+++ b/crates/nu-cli/src/lib.rs
@@ -1,9 +1,11 @@
 mod completions;
 mod errors;
+mod prompt;
 mod syntax_highlight;
 mod validation;
 
 pub use completions::NuCompleter;
 pub use errors::report_error;
+pub use prompt::NushellPrompt;
 pub use syntax_highlight::NuHighlighter;
 pub use validation::NuValidator;

--- a/crates/nu-cli/src/prompt.rs
+++ b/crates/nu-cli/src/prompt.rs
@@ -10,7 +10,7 @@ use {
 pub struct NushellPrompt {
     prompt_command: String,
     prompt_string: String,
-    // These are part of the struct definition in case we want to later allow
+    // These are part of the struct definition in case we want to allow
     // further customization to the shell status
     default_prompt_indicator: String,
     default_vi_insert_prompt_indicator: String,
@@ -25,7 +25,6 @@ impl Default for NushellPrompt {
 }
 
 impl NushellPrompt {
-    /// Constructor for the default prompt, which takes the amount of spaces required between the left and right-hand sides of the prompt
     pub fn new() -> NushellPrompt {
         NushellPrompt {
             prompt_command: "".to_string(),

--- a/crates/nu-cli/src/prompt.rs
+++ b/crates/nu-cli/src/prompt.rs
@@ -1,0 +1,90 @@
+use {
+    reedline::{
+        Prompt, PromptEditMode, PromptHistorySearch, PromptHistorySearchStatus, PromptViMode,
+    },
+    std::borrow::Cow,
+};
+
+/// Nushell prompt definition
+#[derive(Clone)]
+pub struct NushellPrompt {
+    prompt_command: String,
+    prompt_string: String,
+    // These are part of the struct definition in case we want to later allow
+    // further customization to the shell status
+    default_prompt_indicator: String,
+    default_vi_insert_prompt_indicator: String,
+    default_vi_visual_prompt_indicator: String,
+    default_multiline_indicator: String,
+}
+
+impl Default for NushellPrompt {
+    fn default() -> Self {
+        NushellPrompt::new()
+    }
+}
+
+impl NushellPrompt {
+    /// Constructor for the default prompt, which takes the amount of spaces required between the left and right-hand sides of the prompt
+    pub fn new() -> NushellPrompt {
+        NushellPrompt {
+            prompt_command: "".to_string(),
+            prompt_string: "".to_string(),
+            default_prompt_indicator: "〉".to_string(),
+            default_vi_insert_prompt_indicator: ": ".to_string(),
+            default_vi_visual_prompt_indicator: "v ".to_string(),
+            default_multiline_indicator: "::: ".to_string(),
+        }
+    }
+
+    pub fn is_new_prompt(&self, prompt_command: &str) -> bool {
+        self.prompt_command != prompt_command
+    }
+
+    pub fn update_prompt(&mut self, prompt_command: String, prompt_string: String) {
+        self.prompt_command = prompt_command;
+        self.prompt_string = prompt_string;
+    }
+
+    fn default_wrapped_custom_string(&self, str: String) -> String {
+        format!("({})", str)
+    }
+}
+
+impl Prompt for NushellPrompt {
+    fn render_prompt(&self, _: usize) -> Cow<str> {
+        self.prompt_string.as_str().into()
+    }
+
+    fn render_prompt_indicator(&self, edit_mode: PromptEditMode) -> Cow<str> {
+        match edit_mode {
+            PromptEditMode::Default => self.default_prompt_indicator.as_str().into(),
+            PromptEditMode::Emacs => self.default_prompt_indicator.as_str().into(),
+            PromptEditMode::Vi(vi_mode) => match vi_mode {
+                PromptViMode::Normal => self.default_prompt_indicator.as_str().into(),
+                PromptViMode::Insert => self.default_vi_insert_prompt_indicator.as_str().into(),
+                PromptViMode::Visual => self.default_vi_visual_prompt_indicator.as_str().into(),
+            },
+            PromptEditMode::Custom(str) => self.default_wrapped_custom_string(str).into(),
+        }
+    }
+
+    fn render_prompt_multiline_indicator(&self) -> Cow<str> {
+        Cow::Borrowed(self.default_multiline_indicator.as_str())
+    }
+
+    fn render_prompt_history_search_indicator(
+        &self,
+        history_search: PromptHistorySearch,
+    ) -> Cow<str> {
+        let prefix = match history_search.status {
+            PromptHistorySearchStatus::Passing => "",
+            PromptHistorySearchStatus::Failing => "failing ",
+        };
+
+        Cow::Owned(format!(
+            "({}reverse-search: {})",
+            prefix, history_search.term
+        ))
+    }
+}

--- a/crates/nu-protocol/src/engine/evaluation_context.rs
+++ b/crates/nu-protocol/src/engine/evaluation_context.rs
@@ -112,6 +112,10 @@ impl Stack {
         self.0.borrow().env_vars.clone()
     }
 
+    pub fn get_env_var(&self, name: &str) -> Option<String> {
+        self.0.borrow().env_vars.get(name).cloned()
+    }
+
     pub fn print_stack(&self) {
         println!("===frame===");
         println!("vars:");


### PR DESCRIPTION
Introduces the ability to configure the prompt using the `PROMPT_COMMAND` env variable

![image](https://user-images.githubusercontent.com/6942205/135717755-0dda7e85-4d6d-4569-9e75-e15ff04e3e69.png)
