### PR TITLE
add serde derive to Cargo.toml so nu-protocol compiles standalone

### DIFF
--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 [dependencies]
 thiserror = "1.0.29"
 miette = "3.0.0"
-serde = "1.0.130"
+serde = {version = "1.0.130", features = ["derive"]}


### PR DESCRIPTION
We want to be able to compile nu-protocol (standalone) by itself and run the nu-protocol tests.

By adding the derive feature to serde this works...