### PR TITLE
Lines shouldn't trim

### DIFF
--- a/crates/nu-command/src/filters/lines.rs
+++ b/crates/nu-command/src/filters/lines.rs
@@ -62,7 +62,7 @@ impl Command for Lines {
                                 .filter_map(|s| {
                                     if !s.is_empty() {
                                         Some(Value::String {
-                                            val: s.trim().into(),
+                                            val: s.into(),
                                             span,
                                         })
                                     } else {


### PR DESCRIPTION
Trim should be a separate step, so you can do `lines` and join them with newlines to get back the original.