### PR TITLE
The signature of the get command was mistakenly named wrap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,7 +827,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.2.0"
-source = "git+https://github.com/jntrnr/reedline?branch=main#88bded3417e7f6c1242b444f403448de583357f0"
+source = "git+https://github.com/nushell/reedline?branch=main#88bded3417e7f6c1242b444f403448de583357f0"
 dependencies = [
  "chrono",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 members = ["crates/nu-cli", "crates/nu-engine", "crates/nu-parser", "crates/nu-command", "crates/nu-protocol"]
 
 [dependencies]
-reedline = { git = "https://github.com/jntrnr/reedline", branch = "main" }
+reedline = { git = "https://github.com/nushell/reedline", branch = "main" }
 crossterm = "0.21.*"
 nu-cli = { path="./crates/nu-cli" }
 nu-command = { path="./crates/nu-command" }

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -12,4 +12,4 @@ nu-protocol = { path = "../nu-protocol" }
 miette = { version = "3.0.0", features = ["fancy"] }
 thiserror = "1.0.29"
 nu-ansi-term = "0.36.0"
-reedline = { git = "https://github.com/jntrnr/reedline", branch = "main" }
+reedline = { git = "https://github.com/nushell/reedline", branch = "main" }

--- a/crates/nu-command/src/filters/get.rs
+++ b/crates/nu-command/src/filters/get.rs
@@ -15,7 +15,7 @@ impl Command for Get {
     }
 
     fn signature(&self) -> nu_protocol::Signature {
-        Signature::build("wrap").required(
+        Signature::build("get").required(
             "cell_path",
             SyntaxShape::CellPath,
             "the cell path to the data",


### PR DESCRIPTION
Change the location of the reedline repo to the nushell repo from jt

I believe the signature of the get command should read
```rust
        Signature::build("get").required(
```
and it was mistakenly labeled wrap....