### PR TITLE
More external cleanup

### DIFF
--- a/crates/nu-parser/src/flatten.rs
+++ b/crates/nu-parser/src/flatten.rs
@@ -63,8 +63,8 @@ pub fn flatten_expression(
             }
             output
         }
-        Expr::ExternalCall(name, args) => {
-            let mut output = vec![(*name, FlatShape::External)];
+        Expr::ExternalCall(_, name_span, args) => {
+            let mut output = vec![(*name_span, FlatShape::External)];
 
             for arg in args {
                 //output.push((*arg, FlatShape::ExternalArg));

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -108,7 +108,8 @@ pub fn parse_external_call(
     spans: &[Span],
 ) -> (Expression, Option<ParseError>) {
     let mut args = vec![];
-    let name = spans[0];
+    let name_span = spans[0];
+    let name = String::from_utf8_lossy(working_set.get_span_contents(name_span)).to_string();
     let mut error = None;
 
     for span in &spans[1..] {
@@ -129,7 +130,7 @@ pub fn parse_external_call(
     }
     (
         Expression {
-            expr: Expr::ExternalCall(name, args),
+            expr: Expr::ExternalCall(name, name_span, args),
             span: span(spans),
             ty: Type::Unknown,
             custom_completion: None,

--- a/crates/nu-protocol/src/ast/expr.rs
+++ b/crates/nu-protocol/src/ast/expr.rs
@@ -14,7 +14,7 @@ pub enum Expr {
     ),
     Var(VarId),
     Call(Box<Call>),
-    ExternalCall(Span, Vec<Expression>),
+    ExternalCall(String, Span, Vec<Expression>),
     Operator(Operator),
     RowCondition(VarId, Box<Expression>),
     BinaryOp(Box<Expression>, Box<Expression>, Box<Expression>), //lhs, op, rhs


### PR DESCRIPTION
This adds simple support for `^` and cleans up some of the unnecessary evals when running an external call