### PR TITLE
Add `in` and `not-in` operators support

### DIFF
--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -191,6 +191,7 @@ pub fn eval_expression(
                 Operator::Equal => lhs.eq(op_span, &rhs),
                 Operator::NotEqual => lhs.ne(op_span, &rhs),
                 Operator::In => lhs.r#in(op_span, &rhs),
+                Operator::NotIn => lhs.not_in(op_span, &rhs),
                 x => Err(ShellError::UnsupportedOperator(x, op_span)),
             }
         }

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -190,6 +190,7 @@ pub fn eval_expression(
                 Operator::GreaterThanOrEqual => lhs.gte(op_span, &rhs),
                 Operator::Equal => lhs.eq(op_span, &rhs),
                 Operator::NotEqual => lhs.ne(op_span, &rhs),
+                Operator::In => lhs.r#in(op_span, &rhs),
                 x => Err(ShellError::UnsupportedOperator(x, op_span)),
             }
         }

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -295,6 +295,28 @@ pub fn math_result_type(
                     )
                 }
             },
+            Operator::NotIn => match (&lhs.ty, &rhs.ty) {
+                (t, Type::List(u)) if type_compatible(t, u) => (Type::Bool, None),
+                (Type::Int | Type::Float, Type::Range) => (Type::Bool, None),
+                (Type::String, Type::String) => (Type::Bool, None),
+                (Type::String, Type::Record(_, _)) => (Type::Bool, None),
+
+                (Type::Unknown, _) => (Type::Bool, None),
+                (_, Type::Unknown) => (Type::Bool, None),
+                _ => {
+                    *op = Expression::garbage(op.span);
+                    (
+                        Type::Unknown,
+                        Some(ParseError::UnsupportedOperation(
+                            op.span,
+                            lhs.span,
+                            lhs.ty.clone(),
+                            rhs.span,
+                            rhs.ty.clone(),
+                        )),
+                    )
+                }
+            },
 
             _ => {
                 *op = Expression::garbage(op.span);

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -273,6 +273,27 @@ pub fn math_result_type(
                     )
                 }
             },
+            Operator::In => match (&lhs.ty, &rhs.ty) {
+                (t, Type::List(u)) if type_compatible(t, u) => (Type::Bool, None),
+                (Type::Int | Type::Float, Type::Range) => (Type::Bool, None),
+                (Type::String, Type::String) => (Type::Bool, None),
+
+                (Type::Unknown, _) => (Type::Bool, None),
+                (_, Type::Unknown) => (Type::Bool, None),
+                _ => {
+                    *op = Expression::garbage(op.span);
+                    (
+                        Type::Unknown,
+                        Some(ParseError::UnsupportedOperation(
+                            op.span,
+                            lhs.span,
+                            lhs.ty.clone(),
+                            rhs.span,
+                            rhs.ty.clone(),
+                        )),
+                    )
+                }
+            },
 
             _ => {
                 *op = Expression::garbage(op.span);

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -277,6 +277,7 @@ pub fn math_result_type(
                 (t, Type::List(u)) if type_compatible(t, u) => (Type::Bool, None),
                 (Type::Int | Type::Float, Type::Range) => (Type::Bool, None),
                 (Type::String, Type::String) => (Type::Bool, None),
+                (Type::String, Type::Record(_, _)) => (Type::Bool, None),
 
                 (Type::Unknown, _) => (Type::Bool, None),
                 (_, Type::Unknown) => (Type::Bool, None),

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -492,40 +492,6 @@ impl PartialOrd for Value {
                     ..
                 },
             ) if lhs_headers == rhs_headers && lhs == rhs => Some(Ordering::Equal),
-            // Note: This may look a bit strange, but a Stream is still just a List,
-            // it just happens to be in an iterator form instead of a concrete form. If the contained
-            // values are the same then it should be treated as equal
-            (
-                Value::Stream {
-                    stream: stream_lhs, ..
-                },
-                Value::List {
-                    vals: stream_rhs, ..
-                },
-            ) => {
-                let vals_lhs: Vec<Value> = stream_lhs.clone().collect();
-                let vals_rhs: Vec<Value> =
-                    stream_rhs.clone().into_iter().into_value_stream().collect();
-
-                vals_lhs.partial_cmp(&vals_rhs)
-            }
-            // Note: This may look a bit strange, but a Stream is still just a List,
-            // it just happens to be in an iterator form instead of a concrete form. If the contained
-            // values are the same then it should be treated as equal
-            (
-                Value::List {
-                    vals: stream_lhs, ..
-                },
-                Value::Stream {
-                    stream: stream_rhs, ..
-                },
-            ) => {
-                let vals_lhs: Vec<Value> =
-                    stream_lhs.clone().into_iter().into_value_stream().collect();
-                let vals_rhs: Vec<Value> = stream_rhs.clone().collect();
-
-                vals_lhs.partial_cmp(&vals_rhs)
-            }
             (Value::Stream { stream: lhs, .. }, Value::Stream { stream: rhs, .. }) => {
                 lhs.clone().partial_cmp(rhs.clone())
             }
@@ -535,6 +501,9 @@ impl PartialOrd for Value {
             (Value::String { val: lhs, .. }, Value::Stream { stream: rhs, .. }) => {
                 lhs.partial_cmp(&rhs.clone().collect_string())
             }
+            // NOTE: This may look a bit strange, but a `Stream` is still just a `List`, it just
+            // happens to be in an iterator form instead of a concrete form. The contained values
+            // can be compared.
             (Value::Stream { stream: lhs, .. }, Value::List { vals: rhs, .. }) => {
                 lhs.clone().collect::<Vec<Value>>().partial_cmp(rhs)
             }

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -13,7 +13,7 @@ pub use unit::*;
 
 use std::fmt::Debug;
 
-use crate::ast::{CellPath, PathMember, RangeInclusion};
+use crate::ast::{CellPath, PathMember};
 use crate::{span, BlockId, Span, Type};
 
 use crate::ShellError;

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -1066,9 +1066,25 @@ impl Value {
                 span,
             }),
             (lhs, Value::List { vals: rhs, .. }) => Ok(Value::Bool {
-                val: rhs
-                    .iter()
-                    .any(|x| lhs.eq(Span::unknown(), x).map_or(false, |v| v.is_true())),
+                val: rhs.iter().any(|x| {
+                    matches!(
+                        lhs.eq(Span::unknown(), x),
+                        Ok(Value::Bool { val: true, .. })
+                    )
+                }),
+                span,
+            }),
+            (Value::String { val: lhs, .. }, Value::Record { cols: rhs, .. }) => Ok(Value::Bool {
+                val: rhs.contains(lhs),
+                span,
+            }),
+            (lhs, Value::Stream { stream: rhs, .. }) => Ok(Value::Bool {
+                val: rhs.clone().any(|x| {
+                    matches!(
+                        lhs.eq(Span::unknown(), &x),
+                        Ok(Value::Bool { val: true, .. })
+                    )
+                }),
                 span,
             }),
             _ => Err(ShellError::OperatorMismatch {

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -1020,38 +1020,43 @@ impl Value {
 
         match (self, rhs) {
             (lhs, Value::Range { val: rhs, .. }) => Ok(Value::Bool {
-                val: if rhs
-                    .incr
-                    .gt(
+                val: if matches!(
+                    rhs.incr.gt(
                         Span::unknown(),
                         &Value::Int {
                             val: 0,
-                            span: Span::unknown(),
-                        },
-                    )
-                    .map_or(false, |v| v.is_true())
-                {
-                    lhs.gte(Span::unknown(), &rhs.from)
-                        .map_or(false, |v| v.is_true())
-                        && match rhs.inclusion {
-                            RangeInclusion::Inclusive => lhs
-                                .lte(Span::unknown(), &rhs.to)
-                                .map_or(false, |v| v.is_true()),
-                            RangeInclusion::RightExclusive => lhs
-                                .lt(Span::unknown(), &rhs.to)
-                                .map_or(false, |v| v.is_true()),
+                            span: Span::unknown()
                         }
+                    ),
+                    Ok(Value::Bool { val: true, .. })
+                ) {
+                    matches!(
+                        lhs.gte(Span::unknown(), &rhs.from),
+                        Ok(Value::Bool { val: true, .. })
+                    ) && match rhs.inclusion {
+                        RangeInclusion::Inclusive => matches!(
+                            lhs.lte(Span::unknown(), &rhs.to),
+                            Ok(Value::Bool { val: true, .. })
+                        ),
+                        RangeInclusion::RightExclusive => matches!(
+                            lhs.lt(Span::unknown(), &rhs.to),
+                            Ok(Value::Bool { val: true, .. })
+                        ),
+                    }
                 } else {
-                    lhs.lte(Span::unknown(), &rhs.from)
-                        .map_or(false, |v| v.is_true())
-                        && match rhs.inclusion {
-                            RangeInclusion::Inclusive => lhs
-                                .gte(Span::unknown(), &rhs.to)
-                                .map_or(false, |v| v.is_true()),
-                            RangeInclusion::RightExclusive => lhs
-                                .gt(Span::unknown(), &rhs.to)
-                                .map_or(false, |v| v.is_true()),
-                        }
+                    matches!(
+                        lhs.lte(Span::unknown(), &rhs.from),
+                        Ok(Value::Bool { val: true, .. })
+                    ) && match rhs.inclusion {
+                        RangeInclusion::Inclusive => matches!(
+                            lhs.gte(Span::unknown(), &rhs.to),
+                            Ok(Value::Bool { val: true, .. })
+                        ),
+                        RangeInclusion::RightExclusive => matches!(
+                            lhs.gt(Span::unknown(), &rhs.to),
+                            Ok(Value::Bool { val: true, .. })
+                        ),
+                    }
                 },
 
                 span,

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -1020,45 +1020,8 @@ impl Value {
 
         match (self, rhs) {
             (lhs, Value::Range { val: rhs, .. }) => Ok(Value::Bool {
-                val: if matches!(
-                    rhs.incr.gt(
-                        Span::unknown(),
-                        &Value::Int {
-                            val: 0,
-                            span: Span::unknown()
-                        }
-                    ),
-                    Ok(Value::Bool { val: true, .. })
-                ) {
-                    matches!(
-                        lhs.gte(Span::unknown(), &rhs.from),
-                        Ok(Value::Bool { val: true, .. })
-                    ) && match rhs.inclusion {
-                        RangeInclusion::Inclusive => matches!(
-                            lhs.lte(Span::unknown(), &rhs.to),
-                            Ok(Value::Bool { val: true, .. })
-                        ),
-                        RangeInclusion::RightExclusive => matches!(
-                            lhs.lt(Span::unknown(), &rhs.to),
-                            Ok(Value::Bool { val: true, .. })
-                        ),
-                    }
-                } else {
-                    matches!(
-                        lhs.lte(Span::unknown(), &rhs.from),
-                        Ok(Value::Bool { val: true, .. })
-                    ) && match rhs.inclusion {
-                        RangeInclusion::Inclusive => matches!(
-                            lhs.gte(Span::unknown(), &rhs.to),
-                            Ok(Value::Bool { val: true, .. })
-                        ),
-                        RangeInclusion::RightExclusive => matches!(
-                            lhs.gt(Span::unknown(), &rhs.to),
-                            Ok(Value::Bool { val: true, .. })
-                        ),
-                    }
-                },
-
+                // TODO(@arthur-targaryen): Not sure about this clone.
+                val: rhs.clone().into_iter().contains(lhs),
                 span,
             }),
             (Value::String { val: lhs, .. }, Value::String { val: rhs, .. }) => Ok(Value::Bool {
@@ -1079,6 +1042,7 @@ impl Value {
                 span,
             }),
             (lhs, Value::Stream { stream: rhs, .. }) => Ok(Value::Bool {
+                // TODO(@arthur-targaryen): Not sure about this clone too.
                 val: rhs.clone().any(|x| {
                     matches!(
                         lhs.eq(Span::unknown(), &x),

--- a/crates/nu-protocol/src/value/range.rs
+++ b/crates/nu-protocol/src/value/range.rs
@@ -115,7 +115,7 @@ impl Range {
     pub fn contains(&self, item: &Value) -> bool {
         match (item.partial_cmp(&self.from), item.partial_cmp(&self.to)) {
             (Some(Ordering::Greater | Ordering::Equal), Some(Ordering::Less)) => self.moves_up(),
-            (Some(Ordering::Less | Ordering::Equal), Some(Ordering::Greater)) => self.moves_up(),
+            (Some(Ordering::Less | Ordering::Equal), Some(Ordering::Greater)) => !self.moves_up(),
             (Some(_), Some(Ordering::Equal)) => self.is_end_inclusive(),
             (_, _) => false,
         }

--- a/crates/nu-protocol/src/value/range.rs
+++ b/crates/nu-protocol/src/value/range.rs
@@ -104,11 +104,11 @@ impl Range {
         })
     }
 
-    pub fn moves_up(&self) -> bool {
+    fn moves_up(&self) -> bool {
         self.from <= self.to
     }
 
-    pub fn is_end_inclusive(&self) -> bool {
+    fn is_end_inclusive(&self) -> bool {
         matches!(self.inclusion, RangeInclusion::Inclusive)
     }
 

--- a/crates/nu-protocol/src/value/range.rs
+++ b/crates/nu-protocol/src/value/range.rs
@@ -104,10 +104,12 @@ impl Range {
         })
     }
 
+    #[inline]
     fn moves_up(&self) -> bool {
         self.from <= self.to
     }
 
+    #[inline]
     fn is_end_inclusive(&self) -> bool {
         matches!(self.inclusion, RangeInclusion::Inclusive)
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -631,3 +631,13 @@ fn string_in_valuestream() -> TestResult {
         "true",
     )
 }
+
+#[test]
+fn string_not_in_string() -> TestResult {
+    run_test(r#"'d' not-in 'abc'"#, "true")
+}
+
+#[test]
+fn float_not_in_inc_range() -> TestResult {
+    run_test(r#"1.4 not-in 2..9.42"#, "true")
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -569,3 +569,37 @@ fn split_column() -> TestResult {
 fn for_loops() -> TestResult {
     run_test(r#"(for x in [1, 2, 3] { $x + 10 }).1"#, "12")
 }
+
+fn type_in_list_of_this_type() -> TestResult {
+    run_test(r#"42 in [41 42 43]"#, "true")
+}
+
+#[test]
+fn type_in_list_of_non_this_type() -> TestResult {
+    fail_test(r#"'hello' in [41 42 43]"#, "mismatched for operation")
+}
+
+#[test]
+fn string_in_string() -> TestResult {
+    run_test(r#"'z' in 'abc'"#, "false")
+}
+
+#[test]
+fn non_string_in_string() -> TestResult {
+    fail_test(r#"42 in 'abc'"#, "mismatched for operation")
+}
+
+#[test]
+fn int_in_range() -> TestResult {
+    run_test(r#"1 in -4..9.42"#, "true")
+}
+
+#[test]
+fn int_in_exclusive_range() -> TestResult {
+    run_test(r#"3 in 0..<3"#, "false")
+}
+
+#[test]
+fn non_number_in_range() -> TestResult {
+    fail_test(r#"'a' in 1..3"#, "mismatched for operation")
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -590,8 +590,13 @@ fn non_string_in_string() -> TestResult {
 }
 
 #[test]
-fn int_in_range() -> TestResult {
+fn int_in_inc_range() -> TestResult {
     run_test(r#"1 in -4..9.42"#, "true")
+}
+
+#[test]
+fn int_in_dec_range() -> TestResult {
+    run_test(r#"1 in 9.42..-4"#, "true")
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -608,3 +608,26 @@ fn int_in_exclusive_range() -> TestResult {
 fn non_number_in_range() -> TestResult {
     fail_test(r#"'a' in 1..3"#, "mismatched for operation")
 }
+
+#[test]
+fn string_in_record() -> TestResult {
+    run_test(r#""a" in ('{ "a": 13, "b": 14 }' | from json)"#, "true")
+}
+
+#[test]
+fn non_string_in_record() -> TestResult {
+    fail_test(
+        r#"4 in ('{ "a": 13, "b": 14 }' | from json)"#,
+        "mismatch during operation",
+    )
+}
+
+#[test]
+fn string_in_valuestream() -> TestResult {
+    run_test(
+        r#"
+    'Hello' in ("Hello
+    World" | lines)"#,
+        "true",
+    )
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -570,6 +570,7 @@ fn for_loops() -> TestResult {
     run_test(r#"(for x in [1, 2, 3] { $x + 10 }).1"#, "12")
 }
 
+#[test]
 fn type_in_list_of_this_type() -> TestResult {
     run_test(r#"42 in [41 42 43]"#, "true")
 }


### PR DESCRIPTION
## What it does
- Port `in` and `not-in` operators
- Implement `PartialOrd` for `Value`
- Add `Range::contains` method

## To-Do

- [x] `in` operator
  - [x] string in string
  - [x] number in range
  - [x] anything in list of anything
  - [x] string in record
  - [x] anything in stream of anything
  - [ ] *other?*
- [x] `not-in` operator
  - [x] string in string
  - [x] number in range
  - [x] anything in list of anything
  - [x] string in record
  - [x] anything in stream of anything
  - [ ] *other?*