### PR TITLE
Earlier errors

### DIFF
--- a/crates/nu-command/src/core_commands/if_.rs
+++ b/crates/nu-command/src/core_commands/if_.rs
@@ -61,7 +61,7 @@ impl Command for If {
                     Ok(Value::Nothing { span })
                 }
             }
-            _ => Err(ShellError::CantConvert("bool".into(), result.span())),
+            _ => Err(ShellError::CantConvert("bool".into(), result.span()?)),
         }
     }
 }

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -67,7 +67,7 @@ impl Command for Each {
         match input {
             Value::Range { val, .. } => Ok(Value::Stream {
                 stream: val
-                    .into_iter()
+                    .into_range_iter()?
                     .enumerate()
                     .map(move |(idx, x)| {
                         let engine_state = context.engine_state.borrow();

--- a/crates/nu-command/src/formats/from/json.rs
+++ b/crates/nu-command/src/formats/from/json.rs
@@ -71,7 +71,7 @@ impl Command for FromJson {
         call: &Call,
         input: Value,
     ) -> Result<nu_protocol::Value, ShellError> {
-        let span = input.span();
+        let span = input.span()?;
         let mut string_input = input.collect_string();
         string_input.push('\n');
 

--- a/crates/nu-command/src/strings/split/chars.rs
+++ b/crates/nu-command/src/strings/split/chars.rs
@@ -68,24 +68,28 @@ fn split_chars(call: &Call, input: Value) -> Result<nu_protocol::Value, nu_proto
 }
 
 fn split_chars_helper(v: &Value, name: Span) -> Vec<Value> {
-    if let Ok(s) = v.as_string() {
-        let v_span = v.span();
-        s.chars()
-            .collect::<Vec<_>>()
-            .into_iter()
-            .map(move |x| Value::String {
-                val: x.to_string(),
-                span: v_span,
-            })
-            .collect()
-    } else {
-        vec![Value::Error {
-            error: ShellError::PipelineMismatch {
-                expected: Type::String,
-                expected_span: name,
-                origin: v.span(),
-            },
-        }]
+    match v.span() {
+        Ok(v_span) => {
+            if let Ok(s) = v.as_string() {
+                s.chars()
+                    .collect::<Vec<_>>()
+                    .into_iter()
+                    .map(move |x| Value::String {
+                        val: x.to_string(),
+                        span: v_span,
+                    })
+                    .collect()
+            } else {
+                vec![Value::Error {
+                    error: ShellError::PipelineMismatch {
+                        expected: Type::String,
+                        expected_span: name,
+                        origin: v_span,
+                    },
+                }]
+            }
+        }
+        Err(error) => vec![Value::Error { error }],
     }
 }
 

--- a/crates/nu-command/src/strings/split/column.rs
+++ b/crates/nu-command/src/strings/split/column.rs
@@ -109,12 +109,15 @@ fn split_column_helper(
             span: head,
         }
     } else {
-        Value::Error {
-            error: ShellError::PipelineMismatch {
-                expected: Type::String,
-                expected_span: head,
-                origin: v.span(),
+        match v.span() {
+            Ok(span) => Value::Error {
+                error: ShellError::PipelineMismatch {
+                    expected: Type::String,
+                    expected_span: head,
+                    origin: span,
+                },
             },
+            Err(error) => Value::Error { error },
         }
     }
 }

--- a/crates/nu-command/src/strings/split/row.rs
+++ b/crates/nu-command/src/strings/split/row.rs
@@ -48,28 +48,33 @@ fn split_row(
 }
 
 fn split_row_helper(v: &Value, separator: &Spanned<String>, name: Span) -> Vec<Value> {
-    if let Ok(s) = v.as_string() {
-        let splitter = separator.item.replace("\\n", "\n");
-        s.split(&splitter)
-            .filter_map(|s| {
-                if s.trim() != "" {
-                    Some(Value::String {
-                        val: s.into(),
-                        span: v.span(),
+    match v.span() {
+        Ok(v_span) => {
+            if let Ok(s) = v.as_string() {
+                let splitter = separator.item.replace("\\n", "\n");
+                s.split(&splitter)
+                    .filter_map(|s| {
+                        if s.trim() != "" {
+                            Some(Value::String {
+                                val: s.into(),
+                                span: v_span,
+                            })
+                        } else {
+                            None
+                        }
                     })
-                } else {
-                    None
-                }
-            })
-            .collect()
-    } else {
-        vec![Value::Error {
-            error: ShellError::PipelineMismatch {
-                expected: Type::String,
-                expected_span: name,
-                origin: v.span(),
-            },
-        }]
+                    .collect()
+            } else {
+                vec![Value::Error {
+                    error: ShellError::PipelineMismatch {
+                        expected: Type::String,
+                        expected_span: name,
+                        origin: v_span,
+                    },
+                }]
+            }
+        }
+        Err(error) => vec![Value::Error { error }],
     }
 }
 

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -45,7 +45,7 @@ fn eval_call(context: &EvaluationContext, call: &Call, input: Value) -> Result<V
             }
 
             let span = if let Some(rest_item) = rest_items.first() {
-                rest_item.span()
+                rest_item.span()?
             } else {
                 Span::unknown()
             };

--- a/crates/nu-engine/src/from_value.rs
+++ b/crates/nu-engine/src/from_value.rs
@@ -33,7 +33,7 @@ impl FromValue for Spanned<i64> {
                 span: *span,
             }),
 
-            v => Err(ShellError::CantConvert("integer".into(), v.span())),
+            v => Err(ShellError::CantConvert("integer".into(), v.span()?)),
         }
     }
 }
@@ -51,7 +51,7 @@ impl FromValue for i64 {
                 *val as i64,
             ),
 
-            v => Err(ShellError::CantConvert("integer".into(), v.span())),
+            v => Err(ShellError::CantConvert("integer".into(), v.span()?)),
         }
     }
 }
@@ -69,7 +69,7 @@ impl FromValue for Spanned<f64> {
                 span: *span,
             }),
 
-            v => Err(ShellError::CantConvert("float".into(), v.span())),
+            v => Err(ShellError::CantConvert("float".into(), v.span()?)),
         }
     }
 }
@@ -79,7 +79,7 @@ impl FromValue for f64 {
         match v {
             Value::Float { val, .. } => Ok(*val),
             Value::Int { val, .. } => Ok(*val as f64),
-            v => Err(ShellError::CantConvert("float".into(), v.span())),
+            v => Err(ShellError::CantConvert("float".into(), v.span()?)),
         }
     }
 }
@@ -95,7 +95,7 @@ impl FromValue for Spanned<String> {
     fn from_value(v: &Value) -> Result<Self, ShellError> {
         Ok(Spanned {
             item: v.clone().into_string(),
-            span: v.span(),
+            span: v.span()?,
         })
     }
 }
@@ -115,7 +115,7 @@ impl FromValue for ColumnPath {
 
 impl FromValue for CellPath {
     fn from_value(v: &Value) -> Result<Self, ShellError> {
-        let span = v.span();
+        let span = v.span()?;
         match v {
             Value::CellPath { val, .. } => Ok(val.clone()),
             Value::String { val, .. } => Ok(CellPath {
@@ -130,7 +130,7 @@ impl FromValue for CellPath {
                     span,
                 }],
             }),
-            v => Err(ShellError::CantConvert("cell path".into(), v.span())),
+            _ => Err(ShellError::CantConvert("cell path".into(), span)),
         }
     }
 }
@@ -139,7 +139,7 @@ impl FromValue for bool {
     fn from_value(v: &Value) -> Result<Self, ShellError> {
         match v {
             Value::Bool { val, .. } => Ok(*val),
-            v => Err(ShellError::CantConvert("bool".into(), v.span())),
+            v => Err(ShellError::CantConvert("bool".into(), v.span()?)),
         }
     }
 }
@@ -151,7 +151,7 @@ impl FromValue for Spanned<bool> {
                 item: *val,
                 span: *span,
             }),
-            v => Err(ShellError::CantConvert("bool".into(), v.span())),
+            v => Err(ShellError::CantConvert("bool".into(), v.span()?)),
         }
     }
 }
@@ -182,7 +182,7 @@ impl FromValue for Range {
     fn from_value(v: &Value) -> Result<Self, ShellError> {
         match v {
             Value::Range { val, .. } => Ok((**val).clone()),
-            v => Err(ShellError::CantConvert("range".into(), v.span())),
+            v => Err(ShellError::CantConvert("range".into(), v.span()?)),
         }
     }
 }
@@ -194,7 +194,7 @@ impl FromValue for Spanned<Range> {
                 item: (**val).clone(),
                 span: *span,
             }),
-            v => Err(ShellError::CantConvert("range".into(), v.span())),
+            v => Err(ShellError::CantConvert("range".into(), v.span()?)),
         }
     }
 }

--- a/crates/nu-protocol/src/value/range.rs
+++ b/crates/nu-protocol/src/value/range.rs
@@ -122,19 +122,25 @@ impl Range {
             (_, _) => false,
         }
     }
-}
 
-impl IntoIterator for Range {
-    type Item = Value;
+    pub fn into_range_iter(self) -> Result<RangeIterator, ShellError> {
+        let span = self.from.span()?;
 
-    type IntoIter = RangeIterator;
-
-    fn into_iter(self) -> Self::IntoIter {
-        let span = self.from.span();
-
-        RangeIterator::new(self, span)
+        Ok(RangeIterator::new(self, span))
     }
 }
+
+// impl IntoIterator for Range {
+//     type Item = Value;
+
+//     type IntoIter = RangeIterator;
+
+//     fn into_iter(self) -> Self::IntoIter {
+//         let span = self.from.span();
+
+//         RangeIterator::new(self, span)
+//     }
+// }
 
 pub struct RangeIterator {
     curr: Value,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -658,3 +658,11 @@ fn string_not_in_string() -> TestResult {
 fn float_not_in_inc_range() -> TestResult {
     run_test(r#"1.4 not-in 2..9.42"#, "true")
 }
+
+#[test]
+fn earlier_errors() -> TestResult {
+    fail_test(
+        r#"[1, "bob"] | each { $it + 3 } | each { $it / $it } | table"#,
+        "int",
+    )
+}


### PR DESCRIPTION
This adds errors that come a bit earlier when possible. We don't want to underline an error value when we have one, instead, we should just report the error the error value points at.