### PR TITLE
cp, mv, and rm commands need to support -i flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3993e6445baa160675931ec041a5e03ca84b9c6e32a056150d3aa2bdda0a1f45"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "regex",
+ "terminal_size",
+ "unicode-width",
+ "winapi",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,6 +256,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9dd058f8b65922819fabb4a41e7d1964e56344042c26efbccd465202c23fa0c"
+dependencies = [
+ "console",
+ "lazy_static",
+ "tempfile",
+ "zeroize",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,6 +317,12 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "engine-q"
@@ -541,6 +574,7 @@ version = "0.1.0"
 dependencies = [
  "bytesize",
  "chrono",
+ "dialoguer",
  "glob",
  "lscolors",
  "nu-engine",
@@ -1258,3 +1292,9 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "zeroize"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf68b08513768deaa790264a7fac27a58cbf2705cfcdc9448362229217d7e970"

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -25,6 +25,7 @@ chrono = { version = "0.4.19", features = ["serde"] }
 terminal_size = "0.1.17"
 lscolors = { version = "0.8.0", features = ["crossterm"] }
 bytesize = "1.1.0"
+dialoguer = "0.8.0"
 
 [features]
 trash-support = ["trash"]

--- a/crates/nu-command/src/filesystem/cp.rs
+++ b/crates/nu-command/src/filesystem/cp.rs
@@ -29,6 +29,7 @@ impl Command for Cp {
                 "copy recursively through subdirectories",
                 Some('r'),
             )
+            .switch("interactive", "ask user to confirm action", Some('i'))
     }
 
     fn run(
@@ -39,6 +40,14 @@ impl Command for Cp {
     ) -> Result<Value, ShellError> {
         let source: String = call.req(context, 0)?;
         let destination: String = call.req(context, 1)?;
+        let interactive = call.has_flag("interactive");
+
+        if interactive {
+            println!(
+                "Are you shure that you want to move {} to {}?",
+                source, destination
+            );
+        }
 
         let path: PathBuf = current_dir().unwrap();
         let source = path.join(source.as_str());

--- a/crates/nu-command/src/filesystem/cp.rs
+++ b/crates/nu-command/src/filesystem/cp.rs
@@ -12,6 +12,7 @@ use crate::filesystem::util::FileStructure;
 
 pub struct Cp;
 
+#[allow(unused_must_use)]
 impl Command for Cp {
     fn name(&self) -> &str {
         "cp"

--- a/crates/nu-command/src/filesystem/cp.rs
+++ b/crates/nu-command/src/filesystem/cp.rs
@@ -74,7 +74,7 @@ impl Command for Cp {
         }
 
         if interactive && !force {
-            let mut remove_index: Vec<usize> = vec![];
+            let mut remove: Vec<usize> = vec![];
             for (index, file) in sources.iter().enumerate() {
                 let prompt = format!(
                     "Are you shure that you want to copy {} to {}?",
@@ -90,10 +90,13 @@ impl Command for Cp {
                 let input = get_confirmation(prompt)?;
 
                 if !input {
-                    remove_index.push(index);
+                    remove.push(index);
                 }
             }
-            for index in remove_index {
+
+            remove.reverse();
+
+            for index in remove {
                 sources.remove(index);
             }
 

--- a/crates/nu-command/src/filesystem/interactive_helper.rs
+++ b/crates/nu-command/src/filesystem/interactive_helper.rs
@@ -1,0 +1,26 @@
+use dialoguer::Input;
+use std::error::Error;
+
+pub fn get_confirmation(prompt: String) -> Result<bool, Box<dyn Error>> {
+    let input = Input::new()
+        .with_prompt(prompt)
+        .validate_with(|c_input: &String| -> Result<(), String> {
+            if c_input.len() == 1
+                && (c_input == "y" || c_input == "Y" || c_input == "n" || c_input == "N")
+            {
+                Ok(())
+            } else if c_input.len() > 1 {
+                Err("Enter only one letter (Y/N)".to_string())
+            } else {
+                Err("Input not valid".to_string())
+            }
+        })
+        .default("Y/N".into())
+        .interact_text()?;
+
+    if input == "y" || input == "Y" {
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}

--- a/crates/nu-command/src/filesystem/mod.rs
+++ b/crates/nu-command/src/filesystem/mod.rs
@@ -1,5 +1,6 @@
 mod cd;
 mod cp;
+mod interactive_helper;
 mod ls;
 mod mkdir;
 mod mv;

--- a/crates/nu-command/src/filesystem/mv.rs
+++ b/crates/nu-command/src/filesystem/mv.rs
@@ -60,7 +60,7 @@ impl Command for Mv {
         }
 
         if interactive && !force {
-            let mut remove_index: Vec<usize> = vec![];
+            let mut remove: Vec<usize> = vec![];
             for (index, file) in sources.iter().enumerate() {
                 let prompt = format!(
                     "Are you shure that you want to move {} to {}?",
@@ -76,10 +76,13 @@ impl Command for Mv {
                 let input = get_confirmation(prompt)?;
 
                 if !input {
-                    remove_index.push(index);
+                    remove.push(index);
                 }
             }
-            for index in remove_index {
+
+            remove.reverse();
+
+            for index in remove {
                 sources.remove(index);
             }
 

--- a/crates/nu-command/src/filesystem/mv.rs
+++ b/crates/nu-command/src/filesystem/mv.rs
@@ -9,6 +9,7 @@ use nu_protocol::{ShellError, Signature, SyntaxShape, Value};
 
 pub struct Mv;
 
+#[allow(unused_must_use)]
 impl Command for Mv {
     fn name(&self) -> &str {
         "mv"

--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -127,7 +127,7 @@ fn rm(context: &EvaluationContext, call: &Call) -> Result<Value, ShellError> {
     let force = call.has_flag("force");
 
     if interactive && !force {
-        let mut remove_index: Vec<usize> = vec![];
+        let mut remove: Vec<usize> = vec![];
         for (index, file) in targets.iter().enumerate() {
             let prompt: String = format!(
                 "Are you sure that you what to delete {}?",
@@ -137,11 +137,13 @@ fn rm(context: &EvaluationContext, call: &Call) -> Result<Value, ShellError> {
             let input = get_confirmation(prompt)?;
 
             if !input {
-                remove_index.push(index);
+                remove.push(index);
             }
         }
 
-        for index in remove_index {
+        remove.reverse();
+
+        for index in remove {
             targets.remove(index);
         }
 

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -158,6 +158,13 @@ pub enum ShellError {
     #[error("Remove not possible")]
     #[diagnostic(code(nu::shell::remove_not_possible), url(docsrs))]
     RemoveNotPossible(String, #[label("{0}")] Span),
+
+    #[error("No file to be removed")]
+    NoFileToBeRemoved(),
+    #[error("No file to be moved")]
+    NoFileToBeMoved(),
+    #[error("No file to be copied")]
+    NoFileToBeCopied(),
 }
 
 impl From<std::io::Error> for ShellError {


### PR DESCRIPTION
Implements interactive flag to copy, move and remove file system commands
Related to [#3896](https://github.com/nushell/nushell/issues/3162#issuecomment-943692540) on nushell