### PR TITLE
added custom completion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.9.0"
+source = "git+https://github.com/rsteube/dialoguer?branch=fuzzy-paging#92b59e2ca8aed50ed8ebc7e094aa8c7e7f2b6d99"
+dependencies = [
+ "console",
+ "fuzzy-matcher",
+ "lazy_static",
+ "tempfile",
+ "zeroize",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,7 +342,7 @@ version = "0.1.0"
 dependencies = [
  "assert_cmd",
  "crossterm",
- "dialoguer",
+ "dialoguer 0.9.0 (git+https://github.com/rsteube/dialoguer?branch=fuzzy-paging)",
  "miette",
  "nu-cli",
  "nu-command",
@@ -342,8 +354,17 @@ dependencies = [
  "nu-table",
  "nu-term-grid",
  "pretty_assertions",
- "reedline",
+ "reedline 0.2.0 (git+https://github.com/rsteube/reedline?branch=suggestion)",
  "tempfile",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
 ]
 
 [[package]]
@@ -565,7 +586,8 @@ dependencies = [
  "nu-parser",
  "nu-path",
  "nu-protocol",
- "reedline",
+ "reedline 0.2.0 (git+https://github.com/rsteube/reedline?branch=main)",
+ "serde_json",
  "thiserror",
 ]
 
@@ -575,7 +597,7 @@ version = "0.1.0"
 dependencies = [
  "bytesize",
  "chrono",
- "dialoguer",
+ "dialoguer 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob",
  "lscolors",
  "nu-engine",
@@ -901,7 +923,20 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.2.0"
-source = "git+https://github.com/nushell/reedline?branch=main#68a6ab4e5b1ada6d4e0f64bddd305ef1c852fb39"
+source = "git+https://github.com/rsteube/reedline?branch=main#9465e80b98d1c6d47a9db6b4fcda0cd3bbe889d1"
+dependencies = [
+ "chrono",
+ "crossterm",
+ "nu-ansi-term",
+ "serde",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "reedline"
+version = "0.2.0"
+source = "git+https://github.com/rsteube/reedline?branch=suggestion#12940d5d811535e2b9e6e59ee7433a094b10e673"
 dependencies = [
  "chrono",
  "crossterm",
@@ -1175,6 +1210,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,9 @@ edition = "2018"
 members = ["crates/nu-cli", "crates/nu-engine", "crates/nu-parser", "crates/nu-command", "crates/nu-protocol"]
 
 [dependencies]
-reedline = { git = "https://github.com/nushell/reedline", branch = "main" }
+reedline = { git = "https://github.com/rsteube/reedline", branch = "suggestion" }
 crossterm = "0.21.*"
-dialoguer = "0.9.0"
+dialoguer = { git = "https://github.com/rsteube/dialoguer", branch = "fuzzy-paging", features = ["fuzzy-select"] }
 nu-cli = { path="./crates/nu-cli" }
 nu-command = { path="./crates/nu-command" }
 nu-engine = { path="./crates/nu-engine" }

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
+serde_json = "1.0.61"
 nu-engine = { path = "../nu-engine" }
 nu-path = { path = "../nu-path" }
 nu-parser = { path = "../nu-parser" }
@@ -12,4 +13,4 @@ nu-protocol = { path = "../nu-protocol" }
 miette = { version = "3.0.0", features = ["fancy"] }
 thiserror = "1.0.29"
 nu-ansi-term = "0.36.0"
-reedline = { git = "https://github.com/nushell/reedline", branch = "main" }
+reedline = { git = "https://github.com/rsteube/reedline", branch = "main" }


### PR DESCRIPTION
basic idea is to somehow enable registration of custom completers which are invoked and passed the current command line up to cursor position to then return completions as json (or similar)

- uses reedline with `Suggestion` struct for descriptions during completion
- uses dialoguer with added paging to `fuzzy_select` (still some issues with line removal)
- still hardcoded call instead of configuration which command to invoke for completion (should be sth. like https://github.com/rsteube/nushell/blob/0.38.0-a986de8ad_carapace2/crates/nu-completion/src/custom.rs)
- still quite a mess

this currently works with [carapace-bin](https://github.com/rsteube/carapace-bin) after adding the binary to PATH

related: https://github.com/nushell/reedline/pull/167
related: https://github.com/mitsuhiko/dialoguer/compare/master...rsteube:fuzzy-paging