### PR TITLE
Loading modules from files

### DIFF
--- a/crates/nu-command/src/core_commands/use_.rs
+++ b/crates/nu-command/src/core_commands/use_.rs
@@ -15,7 +15,7 @@ impl Command for Use {
     }
 
     fn signature(&self) -> nu_protocol::Signature {
-        Signature::build("use").required("pattern", SyntaxShape::String, "import pattern")
+        Signature::build("use").rest("pattern", SyntaxShape::String, "import pattern parts")
     }
 
     fn run(

--- a/crates/nu-parser/src/errors.rs
+++ b/crates/nu-parser/src/errors.rs
@@ -171,6 +171,10 @@ pub enum ParseError {
     #[diagnostic(code(nu::parser::missing_import_pattern), url(docsrs))]
     MissingImportPattern(#[label = "needs an import pattern"] Span),
 
+    #[error("Wrong import pattern structure.")]
+    #[diagnostic(code(nu::parser::missing_import_pattern), url(docsrs))]
+    WrongImportPattern(#[label = "invalid import pattern structure"] Span),
+
     #[error("Module export not found.")]
     #[diagnostic(code(nu::parser::export_not_found), url(docsrs))]
     ExportNotFound(#[label = "could not find imports"] Span),

--- a/crates/nu-parser/src/errors.rs
+++ b/crates/nu-parser/src/errors.rs
@@ -93,9 +93,9 @@ pub enum ParseError {
     )]
     UnknownCommand(#[label = "unknown command"] Span),
 
-    #[error("Non-UTF8 code.")]
+    #[error("Non-UTF8 string.")]
     #[diagnostic(code(nu::parser::non_utf8), url(docsrs))]
-    NonUtf8(#[label = "non-UTF8 code"] Span),
+    NonUtf8(#[label = "non-UTF8 string"] Span),
 
     #[error("The `{0}` command doesn't have flag `{1}`.")]
     #[diagnostic(code(nu::parser::unknown_flag), url(docsrs))]

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -513,7 +513,8 @@ pub fn parse_use(
                 .into_iter()
                 .map(|(name, id)| {
                     let mut new_name = import_pattern.head.to_vec();
-                    new_name.push(b'.');
+                    new_name.push(b':');
+                    new_name.push(b':');
                     new_name.extend(&name);
                     (new_name, id)
                 })
@@ -628,7 +629,8 @@ pub fn parse_hide(
                     .into_iter()
                     .map(|name| {
                         let mut new_name = import_pattern.head.to_vec();
-                        new_name.push(b'.');
+                        new_name.push(b':');
+                        new_name.push(b':');
                         new_name.extend(&name);
                         new_name
                     })
@@ -639,7 +641,8 @@ pub fn parse_hide(
                         .filter(|n| n == name)
                         .map(|n| {
                             let mut new_name = import_pattern.head.to_vec();
-                            new_name.push(b'.');
+                            new_name.push(b':');
+                            new_name.push(b':');
                             new_name.extend(&n);
                             new_name
                         })
@@ -660,7 +663,8 @@ pub fn parse_hide(
                             .filter_map(|n| if n == name { Some(n.clone()) } else { None })
                             .map(|n| {
                                 let mut new_name = import_pattern.head.to_vec();
-                                new_name.push(b'.');
+                                new_name.push(b':');
+                                new_name.push(b':');
                                 new_name.extend(n);
                                 new_name
                             })

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -218,8 +218,6 @@ pub fn parse_alias(
 
                 let replacement = spans[3..].to_vec();
 
-                //println!("{:?} {:?}", alias_name, replacement);
-
                 working_set.add_alias(alias_name, replacement);
             }
 
@@ -311,15 +309,15 @@ pub fn parse_export(
 
 pub fn parse_module_block(
     working_set: &mut StateWorkingSet,
-    spans: &[Span],
+    span: Span,
 ) -> (Block, Option<ParseError>) {
     let mut error = None;
 
     working_set.enter_scope();
 
-    let source = working_set.get_span_contents(spans[0]);
+    let source = working_set.get_span_contents(span);
 
-    let (output, err) = lex(source, spans[0].start, &[], &[]);
+    let (output, err) = lex(source, span.start, &[], &[]);
     error = error.or(err);
 
     let (output, err) = lite_parse(&output);
@@ -380,8 +378,8 @@ pub fn parse_module_block(
 
                 stmt
             } else {
-                error = Some(ParseError::Expected("not a pipeline".into(), spans[0]));
-                garbage_statement(spans)
+                error = Some(ParseError::Expected("not a pipeline".into(), span));
+                garbage_statement(&[span])
             }
         })
         .into();
@@ -441,7 +439,7 @@ pub fn parse_module(
 
         let block_span = Span { start, end };
 
-        let (block, err) = parse_module_block(working_set, &[block_span]);
+        let (block, err) = parse_module_block(working_set, block_span);
         error = error.or(err);
 
         let block_id = working_set.add_module(&module_name, block);
@@ -530,7 +528,7 @@ pub fn parse_use(
                     let span_end = working_set.next_span_start();
 
                     let (block, err) =
-                        parse_module_block(working_set, &[Span::new(span_start, span_end)]);
+                        parse_module_block(working_set, Span::new(span_start, span_end));
                     error = error.or(err);
 
                     let block_id = working_set.add_module(&module_name, block);

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -495,7 +495,7 @@ pub fn parse_use(
         let (module_name_expr, err) = parse_string(working_set, spans[1]);
         error = error.or(err);
 
-        let (import_pattern, err) = parse_import_pattern(working_set, spans[1]);
+        let (import_pattern, err) = parse_import_pattern(working_set, &spans[1..]);
         error = error.or(err);
 
         let (import_pattern, exports) =
@@ -548,8 +548,7 @@ pub fn parse_use(
                 .into_iter()
                 .map(|(name, id)| {
                     let mut new_name = import_pattern.head.to_vec();
-                    new_name.push(b':');
-                    new_name.push(b':');
+                    new_name.push(b' ');
                     new_name.extend(&name);
                     (new_name, id)
                 })
@@ -634,7 +633,7 @@ pub fn parse_hide(
         let (name_expr, err) = parse_string(working_set, spans[1]);
         error = error.or(err);
 
-        let (import_pattern, err) = parse_import_pattern(working_set, spans[1]);
+        let (import_pattern, err) = parse_import_pattern(working_set, &spans[1..]);
         error = error.or(err);
 
         let exported_names: Vec<Vec<u8>> =
@@ -664,8 +663,7 @@ pub fn parse_hide(
                     .into_iter()
                     .map(|name| {
                         let mut new_name = import_pattern.head.to_vec();
-                        new_name.push(b':');
-                        new_name.push(b':');
+                        new_name.push(b' ');
                         new_name.extend(&name);
                         new_name
                     })
@@ -676,8 +674,7 @@ pub fn parse_hide(
                         .filter(|n| n == name)
                         .map(|n| {
                             let mut new_name = import_pattern.head.to_vec();
-                            new_name.push(b':');
-                            new_name.push(b':');
+                            new_name.push(b' ');
                             new_name.extend(&n);
                             new_name
                         })
@@ -698,8 +695,7 @@ pub fn parse_hide(
                             .filter_map(|n| if n == name { Some(n.clone()) } else { None })
                             .map(|n| {
                                 let mut new_name = import_pattern.head.to_vec();
-                                new_name.push(b':');
-                                new_name.push(b':');
+                                new_name.push(b' ');
                                 new_name.extend(n);
                                 new_name
                             })

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -511,6 +511,7 @@ pub fn parse_use(
             )
         } else {
             // TODO: Handle invalid UTF-8 conversion
+            // TODO: Do not close over when loading module from file
             // It could be a file
             let module_filename = String::from_utf8_lossy(&import_pattern.head).to_string();
             let module_path = Path::new(&module_filename);
@@ -734,6 +735,8 @@ pub fn parse_hide(
         };
 
         for name in names_to_hide {
+            // TODO: `use spam; use spam foo; hide foo` will hide both `foo` and `spam foo` since
+            // they point to the same DeclId. Do we want to keep it that way?
             if working_set.hide_decl(&name).is_none() {
                 error = error.or_else(|| Some(ParseError::UnknownCommand(spans[1])));
             }

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -511,6 +511,7 @@ pub fn parse_use(
                     working_set.get_block(block_id).exports.clone(),
                 )
             } else {
+                //TODO: Fix this
                 // It could be a file
                 let module_filename = String::from_utf8_lossy(&import_pattern.head).to_string();
                 let module_path = Path::new(&module_filename);

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1698,7 +1698,7 @@ pub fn parse_import_pattern(
     let source = working_set.get_span_contents(span);
     let mut error = None;
 
-    let (tokens, err) = lex(source, span.start, &[], &[b'.']);
+    let (tokens, err) = lex(source, span.start, &[], &[b':']);
     error = error.or(err);
 
     if tokens.is_empty() {
@@ -1713,7 +1713,7 @@ pub fn parse_import_pattern(
 
     let head = working_set.get_span_contents(tokens[0].span).to_vec();
 
-    if let Some(tail) = tokens.get(2) {
+    if let Some(tail) = tokens.get(3) {
         // FIXME: expand this to handle deeper imports once we support module imports
         let tail_span = tail.span;
         let tail = working_set.get_span_contents(tail.span);

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1697,26 +1697,8 @@ pub fn parse_import_pattern(
 ) -> (ImportPattern, Option<ParseError>) {
     let mut error = None;
 
-    // return (
-    //     ImportPattern {
-    //         head: vec![],
-    //         members: vec![],
-    //     },
-    //     Some(ParseError::MissingImportPattern(span)),
-    // );
-
-    // return (
-    //     ImportPattern {
-    //         head: vec![],
-    //         members: vec![],
-    //     },
-    //     Some(ParseError::WrongImportPattern(span)),
-    // );
-
     let head = if let Some(head_span) = spans.get(0) {
-        let (head_expr, err) = parse_string(working_set, *head_span);
-        error = error.or(err);
-        working_set.get_span_contents(head_expr.span).to_vec()
+        working_set.get_span_contents(*head_span).to_vec()
     } else {
         return (
             ImportPattern {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1711,6 +1711,33 @@ pub fn parse_import_pattern(
         );
     }
 
+    if (tokens.len() != 1) && (tokens.len() != 4) {
+        return (
+            ImportPattern {
+                head: vec![],
+                members: vec![],
+            },
+            Some(ParseError::WrongImportPattern(span)),
+        );
+    }
+
+    let has_second_colon = if let Some(t) = tokens.get(2) {
+        let potential_colon = working_set.get_span_contents(t.span);
+        potential_colon == b":"
+    } else {
+        false
+    };
+
+    if (tokens.len() == 4) && !has_second_colon {
+        return (
+            ImportPattern {
+                head: vec![],
+                members: vec![],
+            },
+            Some(ParseError::WrongImportPattern(span)),
+        );
+    }
+
     let head = working_set.get_span_contents(tokens[0].span).to_vec();
 
     if let Some(tail) = tokens.get(3) {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1711,6 +1711,7 @@ pub fn parse_import_pattern(
         );
     }
 
+    // We can have either "head" or "head::tail"
     if (tokens.len() != 1) && (tokens.len() != 4) {
         return (
             ImportPattern {
@@ -1721,6 +1722,7 @@ pub fn parse_import_pattern(
         );
     }
 
+    // Check if the second : of the :: is really a :
     let has_second_colon = if let Some(t) = tokens.get(2) {
         let potential_colon = working_set.get_span_contents(t.span);
         potential_colon == b":"
@@ -1729,6 +1731,7 @@ pub fn parse_import_pattern(
     };
 
     if (tokens.len() == 4) && !has_second_colon {
+        // Applies only to the "head::tail" structure; "head" only doesn't have :
         return (
             ImportPattern {
                 head: vec![],

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -501,7 +501,7 @@ impl<'a> StateWorkingSet<'a> {
         let permanent_span_start = self.permanent_state.next_span_start();
 
         if let Some((_, _, last)) = self.delta.file_contents.last() {
-            permanent_span_start + *last
+            *last
         } else {
             permanent_span_start
         }
@@ -561,7 +561,7 @@ impl<'a> StateWorkingSet<'a> {
         if permanent_end <= span.start {
             for (contents, start, finish) in &self.delta.file_contents {
                 if (span.start >= *start) && (span.end <= *finish) {
-                    return &contents[(span.start - permanent_end)..(span.end - permanent_end)];
+                    return &contents[(span.start - start)..(span.end - start)];
                 }
             }
         } else {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -249,7 +249,10 @@ fn alias_2() -> TestResult {
 
 #[test]
 fn alias_2_multi_word() -> TestResult {
-    run_test(r#"def "foo bar" [$x $y] { $x + $y + 10 }; alias f = foo bar 33; f 100"#, "143")
+    run_test(
+        r#"def "foo bar" [$x $y] { $x + $y + 10 }; alias f = foo bar 33; f 100"#,
+        "143",
+    )
 }
 
 #[test]
@@ -537,6 +540,14 @@ fn hides_import_4() -> TestResult {
 fn hides_import_5() -> TestResult {
     fail_test(
         r#"module spam { export def foo [] { "foo" } }; use spam *; hide foo; foo"#,
+        not_found_msg(),
+    )
+}
+
+#[test]
+fn hides_import_6() -> TestResult {
+    fail_test(
+        r#"module spam { export def foo [] { "foo" } }; use spam; hide spam; foo"#,
         not_found_msg(),
     )
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -389,7 +389,7 @@ fn better_block_types() -> TestResult {
 #[test]
 fn module_imports_1() -> TestResult {
     run_test(
-        r#"module foo { export def a [] { 1 }; def b [] { 2 } }; use foo; foo.a"#,
+        r#"module foo { export def a [] { 1 }; def b [] { 2 } }; use foo; foo::a"#,
         "1",
     )
 }
@@ -397,7 +397,7 @@ fn module_imports_1() -> TestResult {
 #[test]
 fn module_imports_2() -> TestResult {
     run_test(
-        r#"module foo { export def a [] { 1 }; def b [] { 2 } }; use foo.a; a"#,
+        r#"module foo { export def a [] { 1 }; def b [] { 2 } }; use foo::a; a"#,
         "1",
     )
 }
@@ -405,7 +405,7 @@ fn module_imports_2() -> TestResult {
 #[test]
 fn module_imports_3() -> TestResult {
     run_test(
-        r#"module foo { export def a [] { 1 }; export def b [] { 2 } }; use foo.*; b"#,
+        r#"module foo { export def a [] { 1 }; export def b [] { 2 } }; use foo::*; b"#,
         "2",
     )
 }
@@ -413,7 +413,7 @@ fn module_imports_3() -> TestResult {
 #[test]
 fn module_imports_4() -> TestResult {
     fail_test(
-        r#"module foo { export def a [] { 1 }; export def b [] { 2 } }; use foo.c"#,
+        r#"module foo { export def a [] { 1 }; export def b [] { 2 } }; use foo::c"#,
         "not find import",
     )
 }
@@ -421,7 +421,7 @@ fn module_imports_4() -> TestResult {
 #[test]
 fn module_imports_5() -> TestResult {
     run_test(
-        r#"module foo { export def a [] { 1 }; def b [] { 2 }; export def c [] { 3 } }; use foo.[a, c]; c"#,
+        r#"module foo { export def a [] { 1 }; def b [] { 2 }; export def c [] { 3 } }; use foo::[a, c]; c"#,
         "3",
     )
 }
@@ -429,7 +429,7 @@ fn module_imports_5() -> TestResult {
 #[test]
 fn module_import_uses_internal_command() -> TestResult {
     run_test(
-        r#"module foo { def b [] { 2 }; export def a [] { b }  }; use foo; foo.a"#,
+        r#"module foo { def b [] { 2 }; export def a [] { b }  }; use foo; foo::a"#,
         "2",
     )
 }
@@ -491,7 +491,7 @@ fn hide_twice_not_allowed() -> TestResult {
 #[test]
 fn hides_import_1() -> TestResult {
     fail_test(
-        r#"module spam { export def foo [] { "foo" } }; use spam; hide spam.foo; foo"#,
+        r#"module spam { export def foo [] { "foo" } }; use spam; hide spam::foo; foo"#,
         not_found_msg(),
     )
 }
@@ -499,7 +499,7 @@ fn hides_import_1() -> TestResult {
 #[test]
 fn hides_import_2() -> TestResult {
     fail_test(
-        r#"module spam { export def foo [] { "foo" } }; use spam; hide spam.*; foo"#,
+        r#"module spam { export def foo [] { "foo" } }; use spam; hide spam::*; foo"#,
         not_found_msg(),
     )
 }
@@ -507,7 +507,7 @@ fn hides_import_2() -> TestResult {
 #[test]
 fn hides_import_3() -> TestResult {
     fail_test(
-        r#"module spam { export def foo [] { "foo" } }; use spam; hide spam.[foo]; foo"#,
+        r#"module spam { export def foo [] { "foo" } }; use spam; hide spam::[foo]; foo"#,
         not_found_msg(),
     )
 }
@@ -515,7 +515,7 @@ fn hides_import_3() -> TestResult {
 #[test]
 fn hides_import_4() -> TestResult {
     fail_test(
-        r#"module spam { export def foo [] { "foo" } }; use spam.foo; hide foo; foo"#,
+        r#"module spam { export def foo [] { "foo" } }; use spam::foo; hide foo; foo"#,
         not_found_msg(),
     )
 }
@@ -523,7 +523,7 @@ fn hides_import_4() -> TestResult {
 #[test]
 fn hides_import_5() -> TestResult {
     fail_test(
-        r#"module spam { export def foo [] { "foo" } }; use spam.*; hide foo; foo"#,
+        r#"module spam { export def foo [] { "foo" } }; use spam::*; hide foo; foo"#,
         not_found_msg(),
     )
 }
@@ -539,7 +539,7 @@ fn def_twice_should_fail() -> TestResult {
 #[test]
 fn use_import_after_hide() -> TestResult {
     run_test(
-        r#"module spam { export def foo [] { "foo" } }; use spam.foo; hide foo; use spam.foo; foo"#,
+        r#"module spam { export def foo [] { "foo" } }; use spam::foo; hide foo; use spam::foo; foo"#,
         "foo",
     )
 }
@@ -547,7 +547,7 @@ fn use_import_after_hide() -> TestResult {
 #[test]
 fn hide_shadowed_decl() -> TestResult {
     run_test(
-        r#"module spam { export def foo [] { "bar" } }; def foo [] { "foo" }; do { use spam.foo; hide foo; foo }"#,
+        r#"module spam { export def foo [] { "bar" } }; def foo [] { "foo" }; do { use spam::foo; hide foo; foo }"#,
         "foo",
     )
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -438,7 +438,7 @@ fn module_import_uses_internal_command() -> TestResult {
 fn module_import_does_not_parse_with_incorrect_delimiter() -> TestResult {
     fail_test(
         r#"module foo { export def a [] { 1 }  }; use foo:.a"#,
-        "not found",
+        not_found_msg(),
     )
 }
 
@@ -446,7 +446,7 @@ fn module_import_does_not_parse_with_incorrect_delimiter() -> TestResult {
 fn module_import_does_not_parse_with_missing_tail() -> TestResult {
     fail_test(
         r#"module foo { export def a [] { 1 }  }; use foo::"#,
-        "not found",
+        not_found_msg(),
     )
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -389,7 +389,7 @@ fn better_block_types() -> TestResult {
 #[test]
 fn module_imports_1() -> TestResult {
     run_test(
-        r#"module foo { export def a [] { 1 }; def b [] { 2 } }; use foo; foo::a"#,
+        r#"module foo { export def a [] { 1 }; def b [] { 2 } }; use foo; foo a"#,
         "1",
     )
 }
@@ -397,7 +397,7 @@ fn module_imports_1() -> TestResult {
 #[test]
 fn module_imports_2() -> TestResult {
     run_test(
-        r#"module foo { export def a [] { 1 }; def b [] { 2 } }; use foo::a; a"#,
+        r#"module foo { export def a [] { 1 }; def b [] { 2 } }; use foo a; a"#,
         "1",
     )
 }
@@ -405,7 +405,7 @@ fn module_imports_2() -> TestResult {
 #[test]
 fn module_imports_3() -> TestResult {
     run_test(
-        r#"module foo { export def a [] { 1 }; export def b [] { 2 } }; use foo::*; b"#,
+        r#"module foo { export def a [] { 1 }; export def b [] { 2 } }; use foo *; b"#,
         "2",
     )
 }
@@ -413,7 +413,7 @@ fn module_imports_3() -> TestResult {
 #[test]
 fn module_imports_4() -> TestResult {
     fail_test(
-        r#"module foo { export def a [] { 1 }; export def b [] { 2 } }; use foo::c"#,
+        r#"module foo { export def a [] { 1 }; export def b [] { 2 } }; use foo c"#,
         "not find import",
     )
 }
@@ -421,7 +421,7 @@ fn module_imports_4() -> TestResult {
 #[test]
 fn module_imports_5() -> TestResult {
     run_test(
-        r#"module foo { export def a [] { 1 }; def b [] { 2 }; export def c [] { 3 } }; use foo::[a, c]; c"#,
+        r#"module foo { export def a [] { 1 }; def b [] { 2 }; export def c [] { 3 } }; use foo [a, c]; c"#,
         "3",
     )
 }
@@ -429,7 +429,7 @@ fn module_imports_5() -> TestResult {
 #[test]
 fn module_import_uses_internal_command() -> TestResult {
     run_test(
-        r#"module foo { def b [] { 2 }; export def a [] { b }  }; use foo; foo::a"#,
+        r#"module foo { def b [] { 2 }; export def a [] { b }  }; use foo; foo a"#,
         "2",
     )
 }
@@ -438,14 +438,6 @@ fn module_import_uses_internal_command() -> TestResult {
 fn module_import_does_not_parse_with_incorrect_delimiter() -> TestResult {
     fail_test(
         r#"module foo { export def a [] { 1 }  }; use foo:.a"#,
-        not_found_msg(),
-    )
-}
-
-#[test]
-fn module_import_does_not_parse_with_missing_tail() -> TestResult {
-    fail_test(
-        r#"module foo { export def a [] { 1 }  }; use foo::"#,
         not_found_msg(),
     )
 }
@@ -507,7 +499,7 @@ fn hide_twice_not_allowed() -> TestResult {
 #[test]
 fn hides_import_1() -> TestResult {
     fail_test(
-        r#"module spam { export def foo [] { "foo" } }; use spam; hide spam::foo; foo"#,
+        r#"module spam { export def foo [] { "foo" } }; use spam; hide spam foo; foo"#,
         not_found_msg(),
     )
 }
@@ -515,7 +507,7 @@ fn hides_import_1() -> TestResult {
 #[test]
 fn hides_import_2() -> TestResult {
     fail_test(
-        r#"module spam { export def foo [] { "foo" } }; use spam; hide spam::*; foo"#,
+        r#"module spam { export def foo [] { "foo" } }; use spam; hide spam *; foo"#,
         not_found_msg(),
     )
 }
@@ -523,7 +515,7 @@ fn hides_import_2() -> TestResult {
 #[test]
 fn hides_import_3() -> TestResult {
     fail_test(
-        r#"module spam { export def foo [] { "foo" } }; use spam; hide spam::[foo]; foo"#,
+        r#"module spam { export def foo [] { "foo" } }; use spam; hide spam [foo]; foo"#,
         not_found_msg(),
     )
 }
@@ -531,7 +523,7 @@ fn hides_import_3() -> TestResult {
 #[test]
 fn hides_import_4() -> TestResult {
     fail_test(
-        r#"module spam { export def foo [] { "foo" } }; use spam::foo; hide foo; foo"#,
+        r#"module spam { export def foo [] { "foo" } }; use spam foo; hide foo; foo"#,
         not_found_msg(),
     )
 }
@@ -539,7 +531,7 @@ fn hides_import_4() -> TestResult {
 #[test]
 fn hides_import_5() -> TestResult {
     fail_test(
-        r#"module spam { export def foo [] { "foo" } }; use spam::*; hide foo; foo"#,
+        r#"module spam { export def foo [] { "foo" } }; use spam *; hide foo; foo"#,
         not_found_msg(),
     )
 }
@@ -555,7 +547,7 @@ fn def_twice_should_fail() -> TestResult {
 #[test]
 fn use_import_after_hide() -> TestResult {
     run_test(
-        r#"module spam { export def foo [] { "foo" } }; use spam::foo; hide foo; use spam::foo; foo"#,
+        r#"module spam { export def foo [] { "foo" } }; use spam foo; hide foo; use spam foo; foo"#,
         "foo",
     )
 }
@@ -563,7 +555,7 @@ fn use_import_after_hide() -> TestResult {
 #[test]
 fn hide_shadowed_decl() -> TestResult {
     run_test(
-        r#"module spam { export def foo [] { "bar" } }; def foo [] { "foo" }; do { use spam::foo; hide foo; foo }"#,
+        r#"module spam { export def foo [] { "bar" } }; def foo [] { "foo" }; do { use spam foo; hide foo; foo }"#,
         "foo",
     )
 }
@@ -571,7 +563,7 @@ fn hide_shadowed_decl() -> TestResult {
 #[test]
 fn hides_all_decls_within_scope() -> TestResult {
     fail_test(
-        r#"module spam { export def foo [] { "bar" } }; def foo [] { "foo" }; use spam::foo; hide foo; foo"#,
+        r#"module spam { export def foo [] { "bar" } }; def foo [] { "foo" }; use spam foo; hide foo; foo"#,
         not_found_msg(),
     )
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -248,6 +248,11 @@ fn alias_2() -> TestResult {
 }
 
 #[test]
+fn alias_2_multi_word() -> TestResult {
+    run_test(r#"def "foo bar" [$x $y] { $x + $y + 10 }; alias f = foo bar 33; f 100"#, "143")
+}
+
+#[test]
 fn block_param1() -> TestResult {
     run_test("[3] | each { $it + 10 } | get 0", "13")
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -571,7 +571,7 @@ fn hide_shadowed_decl() -> TestResult {
 #[test]
 fn hides_all_decls_within_scope() -> TestResult {
     fail_test(
-        r#"module spam { export def foo [] { "bar" } }; def foo [] { "foo" }; use spam.foo; hide foo; foo"#,
+        r#"module spam { export def foo [] { "bar" } }; def foo [] { "foo" }; use spam::foo; hide foo; foo"#,
         not_found_msg(),
     )
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -434,6 +434,22 @@ fn module_import_uses_internal_command() -> TestResult {
     )
 }
 
+#[test]
+fn module_import_does_not_parse_with_incorrect_delimiter() -> TestResult {
+    fail_test(
+        r#"module foo { export def a [] { 1 }  }; use foo:.a"#,
+        "not found",
+    )
+}
+
+#[test]
+fn module_import_does_not_parse_with_missing_tail() -> TestResult {
+    fail_test(
+        r#"module foo { export def a [] { 1 }  }; use foo::"#,
+        "not found",
+    )
+}
+
 // TODO: Test the use/hide tests also as separate lines in REPL (i.e., with  merging the delta in between)
 #[test]
 fn hides_def() -> TestResult {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -442,14 +442,6 @@ fn module_import_uses_internal_command() -> TestResult {
     )
 }
 
-#[test]
-fn module_import_does_not_parse_with_incorrect_delimiter() -> TestResult {
-    fail_test(
-        r#"module foo { export def a [] { 1 }  }; use foo:.a"#,
-        not_found_msg(),
-    )
-}
-
 // TODO: Test the use/hide tests also as separate lines in REPL (i.e., with  merging the delta in between)
 #[test]
 fn hides_def() -> TestResult {


### PR DESCRIPTION
### New import pattern syntax
```
> module spam { def foo [] { "foo" } }

> use spam foo

> foo
```

### Loading modules from files

```
> bash -c "echo 'export def foo [] { \"foo\" }' > spam.nu"

> use spam.nu

> spam foo
foo

> use spam.nu foo

> foo
foo

> hide foo

> hide spam *
```

### Makes it possible to call multi-word commands

Fixes #258.

### Fixes wrong file contents offsets in the working set

See changes in `engine_state.rs` and a commit message in [7112664b](https://github.com/nushell/engine-q/pull/243/commits/7112664b3fb9caceb72bb6d302d33a5637ee0910)

### Left for later:

Currently, the module loaded from file closes over existing scope, which means that local definitions will be visible. We probably do not want that but fixing it would require some thinking -- e.g., we should make some default "overlay" that would be visible but hide the user-defined stuff. So I'll leave it for a future PR.