### PR TITLE
`ls` type lowercase

### DIFF
--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -69,9 +69,9 @@ impl Command for Ls {
                                 span: call_span,
                             },
                             if is_file {
-                                Value::string("File", call_span)
+                                Value::string("file", call_span)
                             } else if is_dir {
-                                Value::string("Dir", call_span)
+                                Value::string("dir", call_span)
                             } else {
                                 Value::Nothing { span: call_span }
                             },


### PR DESCRIPTION
Changes `ls` types to lowercase as suggested [here](https://github.com/nushell/nushell/issues/4092).
It's not case insensitive