### PR TITLE
Added math and min commands

### DIFF
--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -51,6 +51,8 @@ pub fn create_default_context() -> EngineState {
             Math,
             MathAbs,
             MathAvg,
+            MathMax,
+            MathMin,
             Mkdir,
             Module,
             Mv,

--- a/crates/nu-command/src/math/avg.rs
+++ b/crates/nu-command/src/math/avg.rs
@@ -50,6 +50,7 @@ pub fn average(values: &[Value], head: &Span) -> Result<Value, ShellError> {
             span: Span::unknown(),
         },
         values.to_vec(),
+        *head,
     )?;
     match total {
         Value::Filesize { val, span } => Ok(Value::Filesize {

--- a/crates/nu-command/src/math/max.rs
+++ b/crates/nu-command/src/math/max.rs
@@ -1,0 +1,57 @@
+use crate::math::reducers::{reducer_for, Reduce};
+use crate::math::utils::run_with_function;
+use nu_protocol::ast::Call;
+use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::{Example, PipelineData, ShellError, Signature, Span, Value};
+
+#[derive(Clone)]
+pub struct SubCommand;
+
+impl Command for SubCommand {
+    fn name(&self) -> &str {
+        "math max"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("math max")
+    }
+
+    fn usage(&self) -> &str {
+        "Finds the maximum within a list of numbers or tables"
+    }
+
+    fn run(
+        &self,
+        _engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        run_with_function(call, input, maximum)
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Find the maximum of list of numbers",
+            example: "[-50 100 25] | math max",
+            result: Some(Value::test_int(100)),
+        }]
+    }
+}
+
+pub fn maximum(values: &[Value], head: &Span) -> Result<Value, ShellError> {
+    let max_func = reducer_for(Reduce::Maximum);
+    max_func(Value::nothing(), values.to_vec(), *head)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(SubCommand {})
+    }
+}

--- a/crates/nu-command/src/math/min.rs
+++ b/crates/nu-command/src/math/min.rs
@@ -1,0 +1,57 @@
+use crate::math::reducers::{reducer_for, Reduce};
+use crate::math::utils::run_with_function;
+use nu_protocol::ast::Call;
+use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::{Example, PipelineData, ShellError, Signature, Span, Value};
+
+#[derive(Clone)]
+pub struct SubCommand;
+
+impl Command for SubCommand {
+    fn name(&self) -> &str {
+        "math min"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("math min")
+    }
+
+    fn usage(&self) -> &str {
+        "Finds the minimum within a list of numbers or tables"
+    }
+
+    fn run(
+        &self,
+        _engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        run_with_function(call, input, minimum)
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Get the minimum of a list of numbers",
+            example: "[-50 100 25] | math min",
+            result: Some(Value::test_int(-50)),
+        }]
+    }
+}
+
+pub fn minimum(values: &[Value], head: &Span) -> Result<Value, ShellError> {
+    let min_func = reducer_for(Reduce::Minimum);
+    min_func(Value::nothing(), values.to_vec(), *head)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(SubCommand {})
+    }
+}

--- a/crates/nu-command/src/math/mod.rs
+++ b/crates/nu-command/src/math/mod.rs
@@ -1,9 +1,13 @@
 mod abs;
 mod avg;
 pub mod command;
+mod max;
+mod min;
 mod reducers;
 mod utils;
 
 pub use abs::SubCommand as MathAbs;
 pub use avg::SubCommand as MathAvg;
 pub use command::MathCommand as Math;
+pub use max::SubCommand as MathMax;
+pub use min::SubCommand as MathMin;

--- a/crates/nu-command/src/math/reducers.rs
+++ b/crates/nu-command/src/math/reducers.rs
@@ -1,19 +1,73 @@
 use nu_protocol::{ShellError, Span, Value};
+use std::cmp::Ordering;
 
 #[allow(dead_code)]
 pub enum Reduce {
     Summation,
+    Minimum,
+    Maximum,
 }
 
-pub fn reducer_for(
-    command: Reduce,
-) -> Box<dyn Fn(Value, Vec<Value>) -> Result<Value, ShellError> + Send + Sync + 'static> {
+pub type ReducerFunction =
+    Box<dyn Fn(Value, Vec<Value>, Span) -> Result<Value, ShellError> + Send + Sync + 'static>;
+
+pub fn reducer_for(command: Reduce) -> ReducerFunction {
     match command {
-        Reduce::Summation => Box::new(|_, values| sum(values)),
+        Reduce::Summation => Box::new(|_, values, head| sum(values, head)),
+        Reduce::Minimum => Box::new(|_, values, head| min(values, head)),
+        Reduce::Maximum => Box::new(|_, values, head| max(values, head)),
     }
 }
 
-pub fn sum(data: Vec<Value>) -> Result<Value, ShellError> {
+pub fn max(data: Vec<Value>, head: Span) -> Result<Value, ShellError> {
+    let mut biggest = data
+        .first()
+        .ok_or_else(|| ShellError::UnsupportedInput("Empty input".to_string(), Span::unknown()))?
+        .clone();
+
+    for value in &data {
+        if let Some(result) = value.partial_cmp(&biggest) {
+            if result == Ordering::Greater {
+                biggest = value.clone();
+            }
+        } else {
+            return Err(ShellError::OperatorMismatch {
+                op_span: head,
+                lhs_ty: biggest.get_type(),
+                lhs_span: biggest.span()?,
+                rhs_ty: value.get_type(),
+                rhs_span: value.span()?,
+            });
+        }
+    }
+    Ok(biggest)
+}
+
+pub fn min(data: Vec<Value>, head: Span) -> Result<Value, ShellError> {
+    let mut smallest = data
+        .first()
+        .ok_or_else(|| ShellError::UnsupportedInput("Empty input".to_string(), Span::unknown()))?
+        .clone();
+
+    for value in &data {
+        if let Some(result) = value.partial_cmp(&smallest) {
+            if result == Ordering::Less {
+                smallest = value.clone();
+            }
+        } else {
+            return Err(ShellError::OperatorMismatch {
+                op_span: head,
+                lhs_ty: smallest.get_type(),
+                lhs_span: smallest.span()?,
+                rhs_ty: value.get_type(),
+                rhs_span: value.span()?,
+            });
+        }
+    }
+    Ok(smallest)
+}
+
+pub fn sum(data: Vec<Value>, head: Span) -> Result<Value, ShellError> {
     let initial_value = data.get(0);
 
     let mut acc = match initial_value {
@@ -42,7 +96,7 @@ pub fn sum(data: Vec<Value>) -> Result<Value, ShellError> {
             | Value::Float { .. }
             | Value::Filesize { .. }
             | Value::Duration { .. } => {
-                let new_value = acc.add(acc.span().unwrap_or_else(|_| Span::unknown()), value);
+                let new_value = acc.add(head, value);
                 if new_value.is_err() {
                     return new_value;
                 }


### PR DESCRIPTION
Added `math min` and `math max` all the outputs below are pretty much identical to the ones in the old engine.(The `ls`are done in the engine-q file.
```

〉ls | math min
╭──────┬──────╮
│ name │ .git │
│ type │ Dir  │
│ size │ 28 B │
╰──────┴──────╯

```

```
〉ls | math max
╭──────┬─────────╮
│ size │ 33.1 KB │
│ type │ File    │
│ name │ target  │
╰──────┴─────────╯

```
```
〉1 | math max 
1

```
```
〉1 | math min
1

```

```
〉[1 2 4 3] | math max 
4

```
```
〉[1 2 4 3] | math min
1
```

```
〉[[size, height, filesize]; [100, 40, 2TB] [60, 30, 1B]] | math max
╭──────────┬────────╮
│ height   │ 40     │
│ filesize │ 2.0 TB │
│ size     │ 100    │
╰──────────┴────────╯

```
```

〉[[size, height, filesize]; [100, 40, 2TB] [60, 30, 1B]] | math min
╭──────────┬─────╮
│ height   │ 30  │
│ size     │ 60  │
│ filesize │ 1 B │
╰──────────┴─────╯

```

```
〉ps | math max
╭─────────┬───────────────────╮
│ mem     │ 867.8 MB          │
│ name    │ zswap1            │
│ status  │ Unknown(73)       │
│ cpu     │ 329.4117736816406 │
│ virtual │ 275.1 TB          │
│ pid     │ 45949             │
╰─────────┴───────────────────╯

```

```
〉ps | math min
╭─────────┬──────────╮
│ mem     │ —        │
│ virtual │ —        │
│ name    │ (sd-pam) │
│ cpu     │ 0        │
│ pid     │ 1        │
│ status  │ Sleep    │
╰─────────┴──────────╯

```

```
〉[1 x 5 1day] | math min
Error: nu::shell::type_mismatch (link)

  × Type mismatch during operation.
   ╭─[entry #1:1:1]
 1 │ [1 x 5 1day] | math min
   · ▲┬ ┬
   · ││ ╰── string
   · │╰── int
   · ╰── type mismatch for operator
   ╰────


```
