### PR TITLE
Add a simple scope variable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64c01c1c607d25c71bbaa67c113d6c6b36c434744b4fd66691d711b5b1bc0c8b"
+dependencies = [
+ "chrono",
+ "chrono-tz-build",
+ "phf",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db058d493fb2f65f41861bfed7e3fe6335264a9f0f92710cab5bdf01fef09069"
+dependencies = [
+ "parse-zoneinfo",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
 name = "console"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,6 +644,8 @@ version = "0.1.0"
 dependencies = [
  "bytesize",
  "chrono",
+ "chrono-humanize",
+ "chrono-tz",
  "dialoguer",
  "glob",
  "lscolors",
@@ -636,6 +660,7 @@ dependencies = [
  "sysinfo",
  "terminal_size",
  "thiserror",
+ "titlecase",
  "trash",
  "unicode-segmentation",
 ]
@@ -799,6 +824,54 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "winapi",
+]
+
+[[package]]
+name = "parse-zoneinfo"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c705f256449c60da65e11ff6626e0c16a0a0b96aaa348de61376b249bc340f41"
+dependencies = [
+ "regex",
+]
+
+[[package]]
+name = "phf"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9fc3db1018c4b59d7d582a739436478b6035138b6aecbce989fc91c3e98409f"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
+ "uncased",
 ]
 
 [[package]]
@@ -1097,6 +1170,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533494a8f9b724d33625ab53c6c4800f7cc445895924a8ef649222dcb76e938b"
+
+[[package]]
 name = "sized-chunks"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1264,6 +1343,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "titlecase"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f565e410cfc24c2f2a89960b023ca192689d7f77d3f8d4f4af50c2d8affe1117"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "trash"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1277,6 +1366,15 @@ name = "typenum"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
+
+[[package]]
+name = "uncased"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baeed7327e25054889b9bd4f975f32e5f4c5d434042d59ab6cd4142c0a76ed0"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-linebreak"

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -95,16 +95,6 @@ pub fn create_default_context() -> EngineState {
 
         let sig = Signature::build("exit");
         working_set.add_decl(sig.predeclare());
-        let sig = Signature::build("vars");
-        working_set.add_decl(sig.predeclare());
-        let sig = Signature::build("decls");
-        working_set.add_decl(sig.predeclare());
-        let sig = Signature::build("blocks");
-        working_set.add_decl(sig.predeclare());
-        let sig = Signature::build("stack");
-        working_set.add_decl(sig.predeclare());
-        let sig = Signature::build("contents");
-        working_set.add_decl(sig.predeclare());
 
         working_set.render()
     };

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1198,7 +1198,17 @@ pub fn parse_variable_expr(
     } else if contents == b"$nu" {
         return (
             Expression {
-                expr: Expr::Var(0),
+                expr: Expr::Var(nu_protocol::NU_VARIABLE_ID),
+                span,
+                ty: Type::Unknown,
+                custom_completion: None,
+            },
+            None,
+        );
+    } else if contents == b"$scope" {
+        return (
+            Expression {
+                expr: Expr::Var(nu_protocol::SCOPE_VARIABLE_ID),
                 span,
                 ty: Type::Unknown,
                 custom_completion: None,

--- a/crates/nu-protocol/src/lib.rs
+++ b/crates/nu-protocol/src/lib.rs
@@ -11,6 +11,7 @@ mod ty;
 mod value;
 pub use value::Value;
 
+pub use engine::{NU_VARIABLE_ID, SCOPE_VARIABLE_ID};
 pub use example::*;
 pub use id::*;
 pub use pipeline_data::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -225,21 +225,6 @@ fn main() -> Result<()> {
                 Ok(Signal::Success(s)) => {
                     if s.trim() == "exit" {
                         break;
-                    } else if s.trim() == "vars" {
-                        engine_state.print_vars();
-                        continue;
-                    } else if s.trim() == "decls" {
-                        engine_state.print_decls();
-                        continue;
-                    } else if s.trim() == "blocks" {
-                        engine_state.print_blocks();
-                        continue;
-                    } else if s.trim() == "stack" {
-                        stack.print_stack();
-                        continue;
-                    } else if s.trim() == "contents" {
-                        engine_state.print_contents();
-                        continue;
                     }
 
                     eval_source(

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -801,3 +801,8 @@ fn long_flag() -> TestResult {
 fn help_works_with_missing_requirements() -> TestResult {
     run_test(r#"each --help | lines | length"#, "10")
 }
+
+#[test]
+fn scope_variable() -> TestResult {
+    run_test(r"let x = 3; $scope.vars.0", "$x")
+}


### PR DESCRIPTION
Adding a simple `$scope`. Currently, it just lists the names of variables, commands, aliases, and modules that are in scope at the current location. In the future, we could extend this with more info.