### PR TITLE
Move where to helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 3
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -680,6 +690,7 @@ dependencies = [
 name = "nu-command"
 version = "0.1.0"
 dependencies = [
+ "Inflector",
  "bytesize",
  "chrono",
  "chrono-humanize",

--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -138,6 +138,34 @@ impl PipelineData {
             PipelineData::Value(v) => Ok(f(v).into_iter().into_pipeline_data(ctrlc)),
         }
     }
+
+    pub fn filter<F>(
+        self,
+        mut f: F,
+        ctrlc: Option<Arc<AtomicBool>>,
+    ) -> Result<PipelineData, ShellError>
+    where
+        Self: Sized,
+        F: FnMut(&Value) -> bool + 'static + Send,
+    {
+        match self {
+            PipelineData::Value(Value::List { vals, .. }) => {
+                Ok(vals.into_iter().filter(f).into_pipeline_data(ctrlc))
+            }
+            PipelineData::Stream(stream) => Ok(stream.filter(f).into_pipeline_data(ctrlc)),
+            PipelineData::Value(Value::Range { val, .. }) => match val.into_range_iter() {
+                Ok(iter) => Ok(iter.filter(f).into_pipeline_data(ctrlc)),
+                Err(error) => Err(error),
+            },
+            PipelineData::Value(v) => {
+                if f(&v) {
+                    Ok(v.into_pipeline_data())
+                } else {
+                    Ok(Value::Nothing { span: v.span()? }.into_pipeline_data())
+                }
+            }
+        }
+    }
 }
 
 // impl Default for PipelineData {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -849,3 +849,8 @@ fn range_and_reduction() -> TestResult {
 fn precedence_of_or_groups() -> TestResult {
     run_test(r#"4 mod 3 == 0 || 5 mod 5 == 0"#, "true")
 }
+
+#[test]
+fn where_on_ranges() -> TestResult {
+    run_test(r#"1..10 | where $it > 8 | math sum"#, "19")
+}


### PR DESCRIPTION
Moving `where` to a helper for PipelineData. This allows `where` to also work over ranges (like the other helpers)