### PR TITLE
Let list and table exprs get indexed

### DIFF
--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -502,17 +502,18 @@ pub fn eval_variable(
         let mut output_cols = vec![];
         let mut output_vals = vec![];
 
-        let mut vars = vec![];
+        let mut var_names = vec![];
+        let mut var_types = vec![];
         let mut commands = vec![];
         let mut aliases = vec![];
         let mut modules = vec![];
 
         for frame in &engine_state.scope {
             for var in &frame.vars {
-                vars.push(Value::String {
-                    val: String::from_utf8_lossy(var.0).to_string(),
-                    span,
-                });
+                var_names.push(String::from_utf8_lossy(var.0).to_string());
+
+                let var = engine_state.get_var(*var.1);
+                var_types.push(Value::string(var.to_string(), span));
             }
 
             for command in &frame.decls {
@@ -538,7 +539,11 @@ pub fn eval_variable(
         }
 
         output_cols.push("vars".to_string());
-        output_vals.push(Value::List { vals: vars, span });
+        output_vals.push(Value::Record {
+            cols: var_names,
+            vals: var_types,
+            span,
+        });
 
         output_cols.push("commands".to_string());
         output_vals.push(Value::List {

--- a/crates/nu-parser/src/lex.rs
+++ b/crates/nu-parser/src/lex.rs
@@ -145,7 +145,7 @@ pub fn lex_item(
                 let _ = block_level.pop();
             }
         } else if c == b'(' {
-            // We enceountered an opening `(` delimiter.
+            // We encountered an opening `(` delimiter.
             block_level.push(BlockKind::Paren);
         } else if c == b')' {
             // We encountered a closing `)` delimiter. Pop off the opening `(`.

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -429,15 +429,8 @@ pub fn parse_module(
         if block_bytes.ends_with(b"}") {
             end -= 1;
         } else {
-            error = error.or_else(|| {
-                Some(ParseError::Unclosed(
-                    "}".into(),
-                    Span {
-                        start: end,
-                        end: end + 1,
-                    },
-                ))
-            });
+            error =
+                error.or_else(|| Some(ParseError::Unclosed("}".into(), Span { start: end, end })));
         }
 
         let block_span = Span { start, end };

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -804,7 +804,7 @@ fn help_works_with_missing_requirements() -> TestResult {
 
 #[test]
 fn scope_variable() -> TestResult {
-    run_test(r#"let x = 3; $scope.vars.0"#, "$x")
+    run_test(r#"let x = 3; $scope.vars.'$x'"#, "int")
 }
 
 #[test]
@@ -853,4 +853,9 @@ fn precedence_of_or_groups() -> TestResult {
 #[test]
 fn where_on_ranges() -> TestResult {
     run_test(r#"1..10 | where $it > 8 | math sum"#, "19")
+}
+
+#[test]
+fn index_on_list() -> TestResult {
+    run_test(r#"[1, 2, 3].1"#, "2")
 }


### PR DESCRIPTION
This lets you write something like `[1, 2, 3].1` if you want. I think people will assume this is supported (I've even tripped a couple times when I forgot it wasn't).

Might as well add it if it doesn't hurt anything else. I think it's probably okay since it's hard for this to look like something else.