### PR TITLE
Add record literal syntax

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1192,7 +1192,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.2.0"
-source = "git+https://github.com/nushell/reedline?branch=main#550ce9b486b4f1e979ddc37a50d95f27afe37ff3"
+source = "git+https://github.com/nushell/reedline?branch=main#1b244992981e392152b86ceed5c583c31150976c"
 dependencies = [
  "chrono",
  "crossterm 0.22.1",

--- a/crates/nu-command/src/core_commands/do_.rs
+++ b/crates/nu-command/src/core_commands/do_.rs
@@ -33,9 +33,9 @@ impl Command for Do {
         call: &Call,
         input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
-        let block_id = call.positional[0]
-            .as_block()
-            .expect("internal error: expected block");
+        let block: Value = call.req(engine_state, stack, 0)?;
+        let block_id = block.as_block()?;
+
         let rest: Vec<Value> = call.rest(engine_state, stack, 1)?;
 
         let block = engine_state.get_block(block_id);

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -297,6 +297,20 @@ pub fn eval_expression(
                 span: expr.span,
             })
         }
+        Expr::Record(fields) => {
+            let mut cols = vec![];
+            let mut vals = vec![];
+            for (col, val) in fields {
+                cols.push(eval_expression(engine_state, stack, col)?.as_string()?);
+                vals.push(eval_expression(engine_state, stack, val)?);
+            }
+
+            Ok(Value::Record {
+                cols,
+                vals,
+                span: expr.span,
+            })
+        }
         Expr::Table(headers, vals) => {
             let mut output_headers = vec![];
             for expr in headers {

--- a/crates/nu-parser/src/flatten.rs
+++ b/crates/nu-parser/src/flatten.rs
@@ -164,6 +164,14 @@ pub fn flatten_expression(
             }
             output
         }
+        Expr::Record(list) => {
+            let mut output = vec![];
+            for l in list {
+                output.extend(flatten_expression(working_set, &l.0));
+                output.extend(flatten_expression(working_set, &l.1));
+            }
+            output
+        }
         Expr::Keyword(_, span, expr) => {
             let mut output = vec![(*span, FlatShape::Operator)];
             output.extend(flatten_expression(working_set, expr));

--- a/crates/nu-protocol/src/ast/expr.rs
+++ b/crates/nu-protocol/src/ast/expr.rs
@@ -23,6 +23,7 @@ pub enum Expr {
     Block(BlockId),
     List(Vec<Expression>),
     Table(Vec<Expression>, Vec<Vec<Expression>>),
+    Record(Vec<(Expression, Expression)>),
     Keyword(Vec<u8>, Span, Box<Expression>),
     ValueWithUnit(Box<Expression>, Spanned<Unit>),
     Filepath(String),

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -170,6 +170,17 @@ impl Expression {
                 }
                 false
             }
+            Expr::Record(fields) => {
+                for (field_name, field_value) in fields {
+                    if field_name.has_in_variable(working_set) {
+                        return true;
+                    }
+                    if field_value.has_in_variable(working_set) {
+                        return true;
+                    }
+                }
+                false
+            }
             Expr::RowCondition(_, expr) => expr.has_in_variable(working_set),
             Expr::Signature(_) => false,
             Expr::String(_) => false,
@@ -290,6 +301,12 @@ impl Expression {
                 }
                 if let Some(right) = right {
                     right.replace_in_variable(working_set, new_var_id)
+                }
+            }
+            Expr::Record(fields) => {
+                for (field_name, field_value) in fields {
+                    field_name.replace_in_variable(working_set, new_var_id);
+                    field_value.replace_in_variable(working_set, new_var_id);
                 }
             }
             Expr::RowCondition(_, expr) => expr.replace_in_variable(working_set, new_var_id),

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -95,6 +95,17 @@ impl Value {
         }
     }
 
+    pub fn as_block(&self) -> Result<BlockId, ShellError> {
+        match self {
+            Value::Block { val, .. } => Ok(*val),
+            x => Err(ShellError::CantConvert(
+                "block".into(),
+                x.get_type().to_string(),
+                self.span()?,
+            )),
+        }
+    }
+
     /// Get the span for the current value
     pub fn span(&self) -> Result<Span, ShellError> {
         match self {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -889,3 +889,13 @@ fn in_variable_5() -> TestResult {
 fn in_variable_6() -> TestResult {
     run_test(r#"3 | if $in > 6 { $in - 10 } else { $in * 10 }"#, "30")
 }
+
+#[test]
+fn record_1() -> TestResult {
+    run_test(r#"{'a': 'b'} | get a"#, "b")
+}
+
+#[test]
+fn record_2() -> TestResult {
+    run_test(r#"{'b': 'c'}.b"#, "c")
+}


### PR DESCRIPTION
This allows for a JSON-like record syntax:

```
let x = {"b": 5}
```

As well as hjson-like relaxed syntax:

```
let x = {b: 5}
```