### PR TITLE
Add a config variable with engine support

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -35,7 +35,7 @@
 - [x] ctrl-c support
 - [x] operator overflow
 - [x] Support for `$in`
-- [ ] config system
+- [x] config system
 - [ ] shells
 - [ ] plugins
 - [ ] dataframes

--- a/crates/nu-command/src/example_test.rs
+++ b/crates/nu-command/src/example_test.rs
@@ -2,7 +2,7 @@ use nu_engine::eval_block;
 use nu_parser::parse;
 use nu_protocol::{
     engine::{Command, EngineState, Stack, StateWorkingSet},
-    PipelineData, Span,
+    PipelineData, Span, Value, CONFIG_VARIABLE_ID,
 };
 
 use crate::To;
@@ -56,6 +56,16 @@ pub fn test_examples(cmd: impl Command + 'static) {
         engine_state.merge_delta(delta);
 
         let mut stack = Stack::new();
+
+        // Set up our initial config to start from
+        stack.vars.insert(
+            CONFIG_VARIABLE_ID,
+            Value::Record {
+                cols: vec![],
+                vals: vec![],
+                span: Span::unknown(),
+            },
+        );
 
         match eval_block(
             &engine_state,

--- a/crates/nu-command/src/formats/from/csv.rs
+++ b/crates/nu-command/src/formats/from/csv.rs
@@ -78,6 +78,7 @@ fn from_csv(
 
     let noheaders = call.has_flag("noheaders");
     let separator: Option<Value> = call.get_flag(engine_state, stack, "separator")?;
+    let config = stack.get_config()?;
 
     let sep = match separator {
         Some(Value::String { val: s, span }) => {
@@ -97,7 +98,7 @@ fn from_csv(
         _ => ',',
     };
 
-    from_delimited_data(noheaders, sep, input, name)
+    from_delimited_data(noheaders, sep, input, name, &config)
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/formats/from/delimited.rs
+++ b/crates/nu-command/src/formats/from/delimited.rs
@@ -1,5 +1,5 @@
 use csv::ReaderBuilder;
-use nu_protocol::{IntoPipelineData, PipelineData, ShellError, Span, Value};
+use nu_protocol::{Config, IntoPipelineData, PipelineData, ShellError, Span, Value};
 
 fn from_delimited_string_to_value(
     s: String,
@@ -50,8 +50,9 @@ pub fn from_delimited_data(
     sep: char,
     input: PipelineData,
     name: Span,
+    config: &Config,
 ) -> Result<PipelineData, ShellError> {
-    let concat_string = input.collect_string("");
+    let concat_string = input.collect_string("", config);
 
     Ok(
         from_delimited_string_to_value(concat_string, noheaders, sep, name)

--- a/crates/nu-command/src/formats/from/eml.rs
+++ b/crates/nu-command/src/formats/from/eml.rs
@@ -4,6 +4,7 @@ use indexmap::map::IndexMap;
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::Config;
 use nu_protocol::{
     Example, PipelineData, ShellError, Signature, Span, Spanned, SyntaxShape, Value,
 };
@@ -177,7 +178,8 @@ fn from_eml(
     preview_body: Option<Spanned<i64>>,
     head: Span,
 ) -> Result<PipelineData, ShellError> {
-    let value = input.collect_string("");
+    // FIXME? this default config is weird
+    let value = input.collect_string("", &Config::default());
 
     let body_preview = preview_body
         .map(|b| b.item as usize)

--- a/crates/nu-command/src/formats/from/eml.rs
+++ b/crates/nu-command/src/formats/from/eml.rs
@@ -42,7 +42,8 @@ impl Command for FromEml {
         let head = call.head;
         let preview_body: Option<Spanned<i64>> =
             call.get_flag(engine_state, stack, "preview-body")?;
-        from_eml(input, preview_body, head)
+        let config = stack.get_config()?;
+        from_eml(input, preview_body, head, &config)
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -177,9 +178,9 @@ fn from_eml(
     input: PipelineData,
     preview_body: Option<Spanned<i64>>,
     head: Span,
+    config: &Config,
 ) -> Result<PipelineData, ShellError> {
-    // FIXME? this default config is weird
-    let value = input.collect_string("", &Config::default());
+    let value = input.collect_string("", config);
 
     let body_preview = preview_body
         .map(|b| b.item as usize)

--- a/crates/nu-command/src/formats/from/json.rs
+++ b/crates/nu-command/src/formats/from/json.rs
@@ -72,12 +72,13 @@ impl Command for FromJson {
     fn run(
         &self,
         engine_state: &EngineState,
-        _stack: &mut Stack,
+        stack: &mut Stack,
         call: &Call,
         input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, ShellError> {
         let span = call.head;
-        let mut string_input = input.collect_string("");
+        let config = stack.get_config()?;
+        let mut string_input = input.collect_string("", &config);
         string_input.push('\n');
 
         // TODO: turn this into a structured underline of the nu_json error

--- a/crates/nu-command/src/formats/from/tsv.rs
+++ b/crates/nu-command/src/formats/from/tsv.rs
@@ -2,7 +2,7 @@ use super::delimited::from_delimited_data;
 
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{PipelineData, ShellError, Signature};
+use nu_protocol::{Config, PipelineData, ShellError, Signature};
 
 #[derive(Clone)]
 pub struct FromTsv;
@@ -27,20 +27,21 @@ impl Command for FromTsv {
     fn run(
         &self,
         _engine_state: &EngineState,
-        _stack: &mut Stack,
+        stack: &mut Stack,
         call: &Call,
         input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, ShellError> {
-        from_tsv(call, input)
+        let config = stack.get_config()?;
+        from_tsv(call, input, &config)
     }
 }
 
-fn from_tsv(call: &Call, input: PipelineData) -> Result<PipelineData, ShellError> {
+fn from_tsv(call: &Call, input: PipelineData, config: &Config) -> Result<PipelineData, ShellError> {
     let name = call.head;
 
     let noheaders = call.has_flag("noheaders");
 
-    from_delimited_data(noheaders, '\t', input, name)
+    from_delimited_data(noheaders, '\t', input, name, config)
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/formats/from/url.rs
+++ b/crates/nu-command/src/formats/from/url.rs
@@ -1,6 +1,6 @@
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Example, PipelineData, ShellError, Signature, Span, Value};
+use nu_protocol::{Config, Example, PipelineData, ShellError, Signature, Span, Value};
 
 #[derive(Clone)]
 pub struct FromUrl;
@@ -21,12 +21,13 @@ impl Command for FromUrl {
     fn run(
         &self,
         _engine_state: &EngineState,
-        _stack: &mut Stack,
+        stack: &mut Stack,
         call: &Call,
         input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, ShellError> {
         let head = call.head;
-        from_url(input, head)
+        let config = stack.get_config()?;
+        from_url(input, head, &config)
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -52,8 +53,8 @@ impl Command for FromUrl {
     }
 }
 
-fn from_url(input: PipelineData, head: Span) -> Result<PipelineData, ShellError> {
-    let concat_string = input.collect_string("");
+fn from_url(input: PipelineData, head: Span, config: &Config) -> Result<PipelineData, ShellError> {
+    let concat_string = input.collect_string("", config);
 
     let result = serde_urlencoded::from_str::<Vec<(String, String)>>(&concat_string);
 

--- a/crates/nu-command/src/strings/build_string.rs
+++ b/crates/nu-command/src/strings/build_string.rs
@@ -49,10 +49,13 @@ impl Command for BuildString {
         call: &Call,
         _input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        let config = stack.get_config()?;
         let output = call
             .positional
             .iter()
-            .map(|expr| eval_expression(engine_state, stack, expr).map(|val| val.into_string(", ")))
+            .map(|expr| {
+                eval_expression(engine_state, stack, expr).map(|val| val.into_string(", ", &config))
+            })
             .collect::<Result<Vec<String>, ShellError>>()?;
 
         Ok(Value::String {

--- a/crates/nu-command/src/strings/str_/collect.rs
+++ b/crates/nu-command/src/strings/str_/collect.rs
@@ -34,12 +34,14 @@ impl Command for StrCollect {
     ) -> Result<PipelineData, ShellError> {
         let separator: Option<String> = call.opt(engine_state, stack, 0)?;
 
+        let config = stack.get_config()?;
+
         // Hmm, not sure what we actually want. If you don't use debug_string, Date comes out as human readable
         // which feels funny
         #[allow(clippy::needless_collect)]
         let strings: Vec<String> = input
             .into_iter()
-            .map(|value| value.debug_string("\n"))
+            .map(|value| value.debug_string("\n", &config))
             .collect();
 
         let output = if let Some(separator) = separator {

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -429,7 +429,9 @@ pub fn eval_subexpression(
                             // to be used later
                             // FIXME: the trimming of the end probably needs to live in a better place
 
-                            let mut s = input.collect_string("");
+                            let config = stack.get_config()?;
+
+                            let mut s = input.collect_string("", &config);
                             if s.ends_with('\n') {
                                 s.pop();
                             }

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -1,7 +1,7 @@
 use nu_protocol::{
     ast::{Block, Call, Expr, Expression, ImportPattern, ImportPatternMember, Pipeline, Statement},
     engine::StateWorkingSet,
-    span, DeclId, Span, SyntaxShape, Type,
+    span, DeclId, Span, SyntaxShape, Type, CONFIG_VARIABLE_ID,
 };
 use std::path::Path;
 
@@ -800,7 +800,9 @@ pub fn parse_let(
                     .expect("internal error: expected variable");
                 let rhs_type = call.positional[1].ty.clone();
 
-                working_set.set_variable_type(var_id, rhs_type);
+                if var_id != CONFIG_VARIABLE_ID {
+                    working_set.set_variable_type(var_id, rhs_type);
+                }
             }
 
             return (

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -12,6 +12,7 @@ use nu_protocol::{
     },
     engine::StateWorkingSet,
     span, Flag, PositionalArg, Signature, Span, Spanned, SyntaxShape, Type, Unit, VarId,
+    CONFIG_VARIABLE_ID,
 };
 
 use crate::parse_keywords::{
@@ -1201,6 +1202,16 @@ pub fn parse_variable_expr(
             },
             None,
         );
+    } else if contents == b"$config" {
+        return (
+            Expression {
+                expr: Expr::Var(nu_protocol::CONFIG_VARIABLE_ID),
+                span,
+                ty: Type::Unknown,
+                custom_completion: None,
+            },
+            None,
+        );
     }
 
     let (id, err) = parse_variable(working_set, span);
@@ -1909,6 +1920,16 @@ pub fn parse_var_with_opt_type(
                 Some(ParseError::MissingType(spans[*spans_idx])),
             )
         }
+    } else if bytes == b"$config" || bytes == b"config" {
+        (
+            Expression {
+                expr: Expr::Var(CONFIG_VARIABLE_ID),
+                span: spans[*spans_idx],
+                ty: Type::Unknown,
+                custom_completion: None,
+            },
+            None,
+        )
     } else {
         let id = working_set.add_variable(bytes, Type::Unknown);
 

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -1,0 +1,40 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{ShellError, Value};
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct Config {
+    pub filesize_metric: bool,
+    pub table_mode: String,
+}
+
+impl Default for Config {
+    fn default() -> Config {
+        Config {
+            filesize_metric: false,
+            table_mode: "rounded".into(),
+        }
+    }
+}
+
+impl Value {
+    pub fn into_config(self) -> Result<Config, ShellError> {
+        let v = self.as_record()?;
+
+        let mut config = Config::default();
+
+        for (key, value) in v.0.iter().zip(v.1) {
+            match key.as_str() {
+                "filesize_metric" => {
+                    config.filesize_metric = value.as_bool()?;
+                }
+                "table_mode" => {
+                    config.table_mode = value.as_string()?;
+                }
+                _ => {}
+            }
+        }
+
+        Ok(config)
+    }
+}

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -136,13 +136,14 @@ pub struct EngineState {
 pub const NU_VARIABLE_ID: usize = 0;
 pub const SCOPE_VARIABLE_ID: usize = 1;
 pub const IN_VARIABLE_ID: usize = 2;
+pub const CONFIG_VARIABLE_ID: usize = 3;
 
 impl EngineState {
     pub fn new() -> Self {
         Self {
             files: im::vector![],
             file_contents: im::vector![],
-            vars: im::vector![Type::Unknown, Type::Unknown, Type::Unknown],
+            vars: im::vector![Type::Unknown, Type::Unknown, Type::Unknown, Type::Unknown],
             decls: im::vector![],
             blocks: im::vector![],
             scope: im::vector![ScopeFrame::new()],

--- a/crates/nu-protocol/src/lib.rs
+++ b/crates/nu-protocol/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod ast;
+mod config;
 pub mod engine;
 mod example;
 mod id;
@@ -11,7 +12,8 @@ mod ty;
 mod value;
 pub use value::Value;
 
-pub use engine::{IN_VARIABLE_ID, NU_VARIABLE_ID, SCOPE_VARIABLE_ID};
+pub use config::*;
+pub use engine::{CONFIG_VARIABLE_ID, IN_VARIABLE_ID, NU_VARIABLE_ID, SCOPE_VARIABLE_ID};
 pub use example::*;
 pub use id::*;
 pub use pipeline_data::*;

--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -1,6 +1,6 @@
 use std::sync::{atomic::AtomicBool, Arc};
 
-use crate::{ast::PathMember, ShellError, Span, Value, ValueStream};
+use crate::{ast::PathMember, Config, ShellError, Span, Value, ValueStream};
 
 /// The foundational abstraction for input and output to commands
 ///
@@ -51,10 +51,10 @@ impl PipelineData {
         }
     }
 
-    pub fn collect_string(self, separator: &str) -> String {
+    pub fn collect_string(self, separator: &str, config: &Config) -> String {
         match self {
-            PipelineData::Value(v) => v.into_string(separator),
-            PipelineData::Stream(s) => s.into_string(separator),
+            PipelineData::Value(v) => v.into_string(separator, config),
+            PipelineData::Stream(s) => s.into_string(separator, config),
         }
     }
 

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -80,7 +80,7 @@ pub enum ShellError {
     #[diagnostic(code(nu::shell::internal_error), url(docsrs))]
     InternalError(String),
 
-    #[error("Variable not found")]
+    #[error("Variable not found!!!")]
     #[diagnostic(code(nu::shell::variable_not_found), url(docsrs))]
     VariableNotFoundAtRuntime(#[label = "variable not found"] Span),
 

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -15,7 +15,7 @@ use std::collections::HashMap;
 use std::{cmp::Ordering, fmt::Debug};
 
 use crate::ast::{CellPath, PathMember};
-use crate::{did_you_mean, span, BlockId, Span, Spanned, Type};
+use crate::{did_you_mean, span, BlockId, Config, Span, Spanned, Type};
 
 use crate::ShellError;
 
@@ -106,6 +106,28 @@ impl Value {
         }
     }
 
+    pub fn as_record(&self) -> Result<(&[String], &[Value]), ShellError> {
+        match self {
+            Value::Record { cols, vals, .. } => Ok((cols, vals)),
+            x => Err(ShellError::CantConvert(
+                "record".into(),
+                x.get_type().to_string(),
+                self.span()?,
+            )),
+        }
+    }
+
+    pub fn as_bool(&self) -> Result<bool, ShellError> {
+        match self {
+            Value::Bool { val, .. } => Ok(*val),
+            x => Err(ShellError::CantConvert(
+                "boolean".into(),
+                x.get_type().to_string(),
+                self.span()?,
+            )),
+        }
+    }
+
     /// Get the span for the current value
     pub fn span(&self) -> Result<Span, ShellError> {
         match self {
@@ -174,26 +196,26 @@ impl Value {
     }
 
     /// Convert Value into string. Note that Streams will be consumed.
-    pub fn into_string(self, separator: &str) -> String {
+    pub fn into_string(self, separator: &str, config: &Config) -> String {
         match self {
             Value::Bool { val, .. } => val.to_string(),
             Value::Int { val, .. } => val.to_string(),
             Value::Float { val, .. } => val.to_string(),
-            Value::Filesize { val, .. } => format_filesize(val),
+            Value::Filesize { val, .. } => format_filesize(val, config),
             Value::Duration { val, .. } => format_duration(val),
             Value::Date { val, .. } => HumanTime::from(val).to_string(),
             Value::Range { val, .. } => {
                 format!(
                     "{}..{}",
-                    val.from.into_string(", "),
-                    val.to.into_string(", ")
+                    val.from.into_string(", ", config),
+                    val.to.into_string(", ", config)
                 )
             }
             Value::String { val, .. } => val,
             Value::List { vals: val, .. } => format!(
                 "[{}]",
                 val.into_iter()
-                    .map(|x| x.into_string(", "))
+                    .map(|x| x.into_string(", ", config))
                     .collect::<Vec<_>>()
                     .join(separator)
             ),
@@ -201,7 +223,7 @@ impl Value {
                 "{{{}}}",
                 cols.iter()
                     .zip(vals.iter())
-                    .map(|(x, y)| format!("{}: {}", x, y.clone().into_string(", ")))
+                    .map(|(x, y)| format!("{}: {}", x, y.clone().into_string(", ", config)))
                     .collect::<Vec<_>>()
                     .join(separator)
             ),
@@ -214,26 +236,26 @@ impl Value {
     }
 
     /// Convert Value into string. Note that Streams will be consumed.
-    pub fn debug_string(self, separator: &str) -> String {
+    pub fn debug_string(self, separator: &str, config: &Config) -> String {
         match self {
             Value::Bool { val, .. } => val.to_string(),
             Value::Int { val, .. } => val.to_string(),
             Value::Float { val, .. } => val.to_string(),
-            Value::Filesize { val, .. } => format_filesize(val),
+            Value::Filesize { val, .. } => format_filesize(val, config),
             Value::Duration { val, .. } => format_duration(val),
             Value::Date { val, .. } => format!("{:?}", val),
             Value::Range { val, .. } => {
                 format!(
                     "{}..{}",
-                    val.from.into_string(", "),
-                    val.to.into_string(", ")
+                    val.from.into_string(", ", config),
+                    val.to.into_string(", ", config)
                 )
             }
             Value::String { val, .. } => val,
             Value::List { vals: val, .. } => format!(
                 "[{}]",
                 val.into_iter()
-                    .map(|x| x.into_string(", "))
+                    .map(|x| x.into_string(", ", config))
                     .collect::<Vec<_>>()
                     .join(separator)
             ),
@@ -241,7 +263,7 @@ impl Value {
                 "{{{}}}",
                 cols.iter()
                     .zip(vals.iter())
-                    .map(|(x, y)| format!("{}: {}", x, y.clone().into_string(", ")))
+                    .map(|(x, y)| format!("{}: {}", x, y.clone().into_string(", ", config)))
                     .collect::<Vec<_>>()
                     .join(separator)
             ),
@@ -1171,14 +1193,14 @@ pub fn format_duration(duration: i64) -> String {
     )
 }
 
-fn format_filesize(num_bytes: i64) -> String {
+fn format_filesize(num_bytes: i64, config: &Config) -> String {
     let byte = byte_unit::Byte::from_bytes(num_bytes as u128);
 
     if byte.get_bytes() == 0u128 {
         return "—".to_string();
     }
 
-    let byte = byte.get_appropriate_unit(false);
+    let byte = byte.get_appropriate_unit(config.filesize_metric);
 
     match byte.get_unit() {
         byte_unit::ByteUnit::B => format!("{} B ", byte.get_value()),

--- a/crates/nu-protocol/src/value/row.rs
+++ b/crates/nu-protocol/src/value/row.rs
@@ -6,7 +6,7 @@ use crate::*;
 pub struct RowStream(Rc<RefCell<dyn Iterator<Item = Vec<Value>>>>);
 
 impl RowStream {
-    pub fn into_string(self, headers: Vec<String>) -> String {
+    pub fn into_string(self, headers: Vec<String>, config: &Config) -> String {
         format!(
             "[{}]\n[{}]",
             headers
@@ -16,7 +16,7 @@ impl RowStream {
                 .join(", "),
             self.map(|x: Vec<Value>| {
                 x.into_iter()
-                    .map(|x| x.into_string(", "))
+                    .map(|x| x.into_string(", ", config))
                     .collect::<Vec<String>>()
                     .join(", ")
             })

--- a/crates/nu-protocol/src/value/stream.rs
+++ b/crates/nu-protocol/src/value/stream.rs
@@ -19,8 +19,8 @@ pub struct ValueStream {
 }
 
 impl ValueStream {
-    pub fn into_string(self, separator: &str) -> String {
-        self.map(|x: Value| x.into_string(", "))
+    pub fn into_string(self, separator: &str, config: &Config) -> String {
+        self.map(|x: Value| x.into_string(", ", config))
             .collect::<Vec<String>>()
             .join(separator)
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -899,3 +899,21 @@ fn record_1() -> TestResult {
 fn record_2() -> TestResult {
     run_test(r#"{'b': 'c'}.b"#, "c")
 }
+
+#[test]
+fn config_var_1() -> TestResult {
+    // Note: this tests both the config variable and that it is properly captured into a block
+    run_test(
+        r#"let config = {"filesize_metric": $true }; do { 40kb | into string } "#,
+        "39.1 KiB",
+    )
+}
+
+#[test]
+fn config_var_2() -> TestResult {
+    // Note: this tests both the config variable and that it is properly captured into a block
+    run_test(
+        r#"let config = {"filesize_metric": $false }; do { 40kb | into string } "#,
+        "40.0 KB",
+    )
+}


### PR DESCRIPTION
This adds a new builtin variable `$config`. The `$config` variable allows users to update the config by setting this to a record with known fields.

I currently have only ported over a couple settings, but we can keep adding more.

My current config.nu:

```
let $config = {
  filesize_metric: $true
  table_mode: with_love
}
```

The `$config` variable follows all the scoping of normal variables and is assumed captured by blocks.