### PR TITLE
Separate Overlay into its own thing

### DIFF
--- a/crates/nu-command/src/core_commands/use_.rs
+++ b/crates/nu-command/src/core_commands/use_.rs
@@ -38,8 +38,8 @@ impl Command for Use {
             ));
         };
 
-        if let Some(block_id) = engine_state.find_module(&import_pattern.head.name) {
-            let overlay = &engine_state.get_block(block_id).overlay;
+        if let Some(overlay_id) = engine_state.find_overlay(&import_pattern.head.name) {
+            let overlay = engine_state.get_overlay(overlay_id);
 
             let env_vars_to_use = if import_pattern.members.is_empty() {
                 overlay.env_vars_with_head(&import_pattern.head.name)

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -525,7 +525,7 @@ pub fn eval_variable(
         let mut var_types = vec![];
         let mut commands = vec![];
         let mut aliases = vec![];
-        let mut modules = vec![];
+        let mut overlays = vec![];
 
         for frame in &engine_state.scope {
             for var in &frame.vars {
@@ -549,9 +549,9 @@ pub fn eval_variable(
                 });
             }
 
-            for module in &frame.modules {
-                modules.push(Value::String {
-                    val: String::from_utf8_lossy(module.0).to_string(),
+            for overlay in &frame.overlays {
+                overlays.push(Value::String {
+                    val: String::from_utf8_lossy(overlay.0).to_string(),
                     span,
                 });
             }
@@ -576,9 +576,9 @@ pub fn eval_variable(
             span,
         });
 
-        output_cols.push("modules".to_string());
+        output_cols.push("overlays".to_string());
         output_vals.push(Value::List {
-            vals: modules,
+            vals: overlays,
             span,
         });
 

--- a/crates/nu-protocol/src/ast/block.rs
+++ b/crates/nu-protocol/src/ast/block.rs
@@ -1,6 +1,6 @@
 use std::ops::{Index, IndexMut};
 
-use crate::{Overlay, Signature, VarId};
+use crate::{Signature, VarId};
 
 use super::Statement;
 
@@ -8,7 +8,6 @@ use super::Statement;
 pub struct Block {
     pub signature: Box<Signature>,
     pub stmts: Vec<Statement>,
-    pub overlay: Overlay,
     pub captures: Vec<VarId>,
 }
 
@@ -47,17 +46,7 @@ impl Block {
         Self {
             signature: Box::new(Signature::new("")),
             stmts: vec![],
-            overlay: Overlay::new(),
             captures: vec![],
-        }
-    }
-
-    pub fn with_overlay(self, overlay: Overlay) -> Self {
-        Self {
-            signature: self.signature,
-            stmts: self.stmts,
-            overlay,
-            captures: self.captures,
         }
     }
 }
@@ -70,7 +59,6 @@ where
         Self {
             signature: Box::new(Signature::new("")),
             stmts: stmts.collect(),
-            overlay: Overlay::new(),
             captures: vec![],
         }
     }

--- a/crates/nu-protocol/src/id.rs
+++ b/crates/nu-protocol/src/id.rs
@@ -1,3 +1,4 @@
 pub type VarId = usize;
 pub type DeclId = usize;
 pub type BlockId = usize;
+pub type OverlayId = usize;


### PR DESCRIPTION
Overlay is no longer attached to a Block.
Makes access to overlays more streamlined by removing this one indirection.
Also makes it easier to create standalone overlays without a block which might come in handy.

This is a precursor to reliable hiding of exported environment variables. The current plan is that in the Stack, the env vars would reference OverlayId they belong to.