### PR TITLE
Plugins signature load

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,6 +947,7 @@ dependencies = [
  "miette",
  "nu-plugin",
  "nu-protocol",
+ "serde_json",
  "thiserror",
 ]
 
@@ -977,6 +978,7 @@ dependencies = [
  "im",
  "miette",
  "serde",
+ "serde_json",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ ctrlc = "3.2.1"
 # mimalloc = { version = "*", default-features = false }
 
 [features]
-plugin = ["nu-plugin", "nu-parser/plugin", "nu-command/plugin"]
+plugin = ["nu-plugin", "nu-parser/plugin", "nu-command/plugin", "nu-protocol/plugin"]
 default = ["plugin"]
 
 [dev-dependencies]

--- a/crates/nu-command/src/core_commands/help.rs
+++ b/crates/nu-command/src/core_commands/help.rs
@@ -114,6 +114,12 @@ fn help(
                     span: head,
                 });
 
+                cols.push("is_plugin".into());
+                vals.push(Value::Bool {
+                    val: cmd.2,
+                    span: head,
+                });
+
                 cols.push("usage".into());
                 vals.push(Value::String { val: c, span: head });
 
@@ -154,6 +160,12 @@ fn help(
                 cols.push("category".into());
                 vals.push(Value::String {
                     val: cmd.0.category.to_string(),
+                    span: head,
+                });
+
+                cols.push("is_plugin".into());
+                vals.push(Value::Bool {
+                    val: cmd.2,
                     span: head,
                 });
 

--- a/crates/nu-command/src/core_commands/register.rs
+++ b/crates/nu-command/src/core_commands/register.rs
@@ -21,6 +21,7 @@ impl Command for Register {
                 SyntaxShape::Filepath,
                 "location of bin for plugin",
             )
+            .optional("signature", SyntaxShape::Any, "plugin signature")
             .category(Category::Core)
     }
 

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -145,7 +145,7 @@ pub fn create_default_context() -> EngineState {
         working_set.render()
     };
 
-    engine_state.merge_delta(delta);
+    let _ = engine_state.merge_delta(delta);
 
     engine_state
 }

--- a/crates/nu-command/src/example_test.rs
+++ b/crates/nu-command/src/example_test.rs
@@ -33,7 +33,7 @@ pub fn test_examples(cmd: impl Command + 'static) {
         working_set.render()
     };
 
-    engine_state.merge_delta(delta);
+    let _ = engine_state.merge_delta(delta);
 
     for example in examples {
         // Skip tests that don't have results to compare to
@@ -53,7 +53,7 @@ pub fn test_examples(cmd: impl Command + 'static) {
             (output, working_set.render())
         };
 
-        engine_state.merge_delta(delta);
+        let _ = engine_state.merge_delta(delta);
 
         let mut stack = Stack::new();
 

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -585,7 +585,7 @@ pub fn eval_variable(
 
                 cols.push("is_plugin".to_string());
                 vals.push(Value::Bool {
-                    val: decl.is_plugin(),
+                    val: decl.is_plugin().is_some(),
                     span,
                 });
 

--- a/crates/nu-parser/Cargo.toml
+++ b/crates/nu-parser/Cargo.toml
@@ -8,6 +8,7 @@ miette = "3.0.0"
 thiserror = "1.0.29"
 nu-protocol = { path = "../nu-protocol"}
 nu-plugin = { path = "../nu-plugin", optional=true}
+serde_json = "1.0"
 
 [features]
 plugin = ["nu-plugin"]

--- a/crates/nu-parser/src/errors.rs
+++ b/crates/nu-parser/src/errors.rs
@@ -192,6 +192,6 @@ pub enum ParseError {
     FileNotFound(String),
 
     #[error("Plugin error")]
-    #[diagnostic(code(nu::parser::export_not_found), url(docsrs))]
+    #[diagnostic(code(nu::parser::plugin_error), url(docsrs))]
     PluginError(String),
 }

--- a/crates/nu-plugin/src/plugin.rs
+++ b/crates/nu-plugin/src/plugin.rs
@@ -215,8 +215,8 @@ impl Command for PluginDeclaration {
         Ok(pipeline_data)
     }
 
-    fn is_plugin(&self) -> bool {
-        true
+    fn is_plugin(&self) -> Option<&str> {
+        Some(self.filename.as_str())
     }
 }
 

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -13,3 +13,6 @@ chrono = { version="0.4.19", features=["serde"] }
 chrono-humanize = "0.2.1"
 byte-unit = "4.0.9"
 im = "15.0.0"
+
+[dev-dependencies]
+serde_json = "1.0"

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -13,6 +13,10 @@ chrono = { version="0.4.19", features=["serde"] }
 chrono-humanize = "0.2.1"
 byte-unit = "4.0.9"
 im = "15.0.0"
+serde_json = { version = "1.0", optional = true }
+
+[features]
+plugin = ["serde_json"]
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/crates/nu-protocol/src/engine/command.rs
+++ b/crates/nu-protocol/src/engine/command.rs
@@ -47,8 +47,8 @@ pub trait Command: Send + Sync + CommandClone {
     }
 
     // Is a plugin command
-    fn is_plugin(&self) -> bool {
-        false
+    fn is_plugin(&self) -> Option<&str> {
+        None
     }
 
     // If command is a block i.e. def blah [] { }, get the block id

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -5,6 +5,7 @@ use crate::{
 use core::panic;
 use std::{
     collections::HashMap,
+    path::PathBuf,
     sync::{atomic::AtomicBool, Arc},
 };
 
@@ -136,6 +137,7 @@ pub struct EngineState {
     overlays: im::Vector<Overlay>,
     pub scope: im::Vector<ScopeFrame>,
     pub ctrlc: Option<Arc<AtomicBool>>,
+    pub plugin_signatures: Option<PathBuf>,
 }
 
 pub const NU_VARIABLE_ID: usize = 0;
@@ -154,6 +156,7 @@ impl EngineState {
             overlays: im::vector![],
             scope: im::vector![ScopeFrame::new()],
             ctrlc: None,
+            plugin_signatures: None,
         }
     }
 
@@ -250,6 +253,10 @@ impl EngineState {
         }
 
         None
+    }
+
+    pub fn plugin_decls(&self) -> impl Iterator<Item = &Box<dyn Command + 'static>> {
+        self.decls.iter().filter(|decl| decl.is_plugin().is_some())
     }
 
     pub fn find_overlay(&self, name: &[u8]) -> Option<OverlayId> {

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -372,7 +372,7 @@ impl EngineState {
         output
     }
 
-    pub fn get_signatures_with_examples(&self) -> Vec<(Signature, Vec<Example>)> {
+    pub fn get_signatures_with_examples(&self) -> Vec<(Signature, Vec<Example>, bool)> {
         let mut output = vec![];
         for decl in self.decls.iter() {
             if decl.get_block_id().is_none() {
@@ -380,7 +380,7 @@ impl EngineState {
                 signature.usage = decl.usage().to_string();
                 signature.extra_usage = decl.extra_usage().to_string();
 
-                output.push((signature, decl.examples()));
+                output.push((signature, decl.examples(), decl.is_plugin().is_some()));
             }
         }
 

--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -1,3 +1,6 @@
+use serde::Deserialize;
+use serde::Serialize;
+
 use crate::ast::Call;
 use crate::engine::Command;
 use crate::engine::EngineState;
@@ -7,7 +10,7 @@ use crate::PipelineData;
 use crate::SyntaxShape;
 use crate::VarId;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Flag {
     pub long: String,
     pub short: Option<char>,
@@ -18,7 +21,7 @@ pub struct Flag {
     pub var_id: Option<VarId>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PositionalArg {
     pub name: String,
     pub desc: String,
@@ -27,7 +30,7 @@ pub struct PositionalArg {
     pub var_id: Option<VarId>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Category {
     Default,
     Conversions,
@@ -66,7 +69,7 @@ impl std::fmt::Display for Category {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Signature {
     pub name: String,
     pub usage: String,

--- a/crates/nu-protocol/src/syntax_shape.rs
+++ b/crates/nu-protocol/src/syntax_shape.rs
@@ -1,7 +1,9 @@
+use serde::{Deserialize, Serialize};
+
 use crate::Type;
 
 /// The syntactic shapes that values must match to be passed into a command. You can think of this as the type-checking that occurs when you call a function.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SyntaxShape {
     /// A specific match to a word or symbol
     Keyword(Vec<u8>, Box<SyntaxShape>),

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,7 +118,10 @@ fn main() -> Result<()> {
             (output, working_set.render())
         };
 
-        engine_state.merge_delta(delta);
+        if let Err(err) = engine_state.merge_delta(delta) {
+            let working_set = StateWorkingSet::new(&engine_state);
+            report_error(&working_set, &err);
+        }
 
         let mut stack = nu_protocol::engine::Stack::new();
 
@@ -185,10 +188,9 @@ fn main() -> Result<()> {
             config_path.push("nushell");
             config_path.push("config.nu");
 
-            // FIXME: remove this message when we're ready
-            println!("Loading config from: {:?}", config_path);
-
             if config_path.exists() {
+                // FIXME: remove this message when we're ready
+                println!("Loading config from: {:?}", config_path);
                 let config_filename = config_path.to_string_lossy().to_owned();
 
                 if let Ok(contents) = std::fs::read_to_string(&config_path) {
@@ -206,15 +208,23 @@ fn main() -> Result<()> {
             None
         };
 
-        // Path to store plugins signatures
-        engine_state.plugin_signatures = if let Some(mut plugin_path) = nu_path::config_dir() {
-            plugin_path.push("nushell");
-            plugin_path.push("plugin.nu");
+        #[cfg(feature = "plugin")]
+        {
+            // Reading signatures from signature file
+            // The plugin.nu file stores the parsed signature collected from each registered plugin
+            if let Some(mut plugin_path) = nu_path::config_dir() {
+                // Path to store plugins signatures
+                plugin_path.push("nushell");
+                plugin_path.push("plugin.nu");
+                engine_state.plugin_signatures = Some(plugin_path.clone());
 
-            Some(plugin_path)
-        } else {
-            None
-        };
+                let plugin_filename = plugin_path.to_string_lossy().to_owned();
+
+                if let Ok(contents) = std::fs::read_to_string(&plugin_path) {
+                    eval_source(&mut engine_state, &mut stack, &contents, &plugin_filename);
+                }
+            }
+        }
 
         loop {
             //Reset the ctrl-c handler
@@ -397,7 +407,10 @@ fn eval_source(
         (output, working_set.render())
     };
 
-    engine_state.merge_delta(delta);
+    if let Err(err) = engine_state.merge_delta(delta) {
+        let working_set = StateWorkingSet::new(engine_state);
+        report_error(&working_set, &err);
+    }
 
     match eval_block(
         engine_state,

--- a/src/main.rs
+++ b/src/main.rs
@@ -206,6 +206,16 @@ fn main() -> Result<()> {
             None
         };
 
+        // Path to store plugins signatures
+        engine_state.plugin_signatures = if let Some(mut plugin_path) = nu_path::config_dir() {
+            plugin_path.push("nushell");
+            plugin_path.push("plugin.nu");
+
+            Some(plugin_path)
+        } else {
+            None
+        };
+
         loop {
             //Reset the ctrl-c handler
             ctrlc.store(false, Ordering::SeqCst);


### PR DESCRIPTION
The signatures for the plugins are stored in file `plugin.nu` which are used every time nushell starts. This reduces the loading time since it isnt required to call to each plugin to get its signature