### PR TITLE
Port `all?` command

### DIFF
--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -20,6 +20,7 @@ pub fn create_default_context() -> EngineState {
         // TODO: sort default context items categorically
         bind_command!(
             Alias,
+            All,
             Append,
             Benchmark,
             BuildString,

--- a/crates/nu-command/src/filters/all.rs
+++ b/crates/nu-command/src/filters/all.rs
@@ -1,8 +1,9 @@
 use nu_engine::eval_expression;
-use nu_protocol::ast::{Call, Expr, Expression};
-use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::IntoPipelineData;
-use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, SyntaxShape};
+use nu_protocol::{
+    ast::{Call, Expr, Expression},
+    engine::{Command, EngineState, Stack},
+    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, SyntaxShape,
+};
 
 #[derive(Clone)]
 pub struct All;

--- a/crates/nu-command/src/filters/all.rs
+++ b/crates/nu-command/src/filters/all.rs
@@ -93,6 +93,6 @@ mod tests {
     fn test_examples() {
         use crate::test_examples;
 
-        test_examples(All {})
+        test_examples(All)
     }
 }

--- a/crates/nu-command/src/filters/all.rs
+++ b/crates/nu-command/src/filters/all.rs
@@ -1,0 +1,88 @@
+use nu_engine::eval_expression;
+use nu_protocol::ast::{Call, Expr, Expression};
+use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, SyntaxShape};
+
+#[derive(Clone)]
+pub struct All;
+
+impl Command for All {
+    fn name(&self) -> &str {
+        "all?"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .required(
+                "predicate",
+                SyntaxShape::RowCondition,
+                "the predicate that must match",
+            )
+            .category(Category::Filters)
+    }
+
+    fn usage(&self) -> &str {
+        "Test if every element of the input matches a predicate."
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        use nu_protocol::Value;
+
+        vec![
+            Example {
+                description: "Find if services are running",
+                example: "echo [[status]; [UP] [UP]] | all? status == UP",
+                result: Some(Value::from(true)),
+            },
+            Example {
+                description: "Check that all values are even",
+                example: "echo [2 4 6 8] | all? ($it mod 2) == 0",
+                result: Some(Value::from(true)),
+            },
+        ]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let predicate = &call.positional[0];
+
+        let (var_id, expr) = match predicate {
+            Expression {
+                expr: Expr::RowCondition(var_id, expr),
+                ..
+            } => (*var_id, expr.clone()),
+            _ => return Err(ShellError::InternalError("Expected row condition".into())),
+        };
+
+        let ctrlc = engine_state.ctrlc.clone();
+        let engine_state = engine_state.clone();
+
+        // FIXME: Expensive clone. I would need a way to collect the captures of the `RowCondition`.
+        let mut stack = stack.clone();
+
+        input.all(
+            move |value| {
+                stack.add_var(var_id, value);
+                eval_expression(&engine_state, &mut stack, &expr).map_or(false, |v| v.is_true())
+            },
+            ctrlc,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(All {})
+    }
+}

--- a/crates/nu-command/src/filters/all.rs
+++ b/crates/nu-command/src/filters/all.rs
@@ -64,7 +64,7 @@ impl Command for All {
         let ctrlc = engine_state.ctrlc.clone();
         let engine_state = engine_state.clone();
 
-        // FIXME: Expensive clone. I would need a way to collect the captures of the `RowCondition`.
+        // FIXME: Expensive clone. We would need a way to collect the captures of the `RowCondition`.
         let mut stack = stack.clone();
 
         Ok(input

--- a/crates/nu-command/src/filters/all.rs
+++ b/crates/nu-command/src/filters/all.rs
@@ -76,7 +76,7 @@ impl Command for All {
                     stack.add_var(var_id, value);
                 }
 
-                eval_block(&engine_state, &mut stack, &block, PipelineData::new(span))
+                eval_block(&engine_state, &mut stack, block, PipelineData::new(span))
                     .map_or(false, |pipeline_data| {
                         pipeline_data.into_value(span).is_true()
                     })

--- a/crates/nu-command/src/filters/mod.rs
+++ b/crates/nu-command/src/filters/mod.rs
@@ -1,3 +1,4 @@
+mod all;
 mod append;
 mod collect;
 mod drop;
@@ -17,6 +18,7 @@ mod where_;
 mod wrap;
 mod zip;
 
+pub use all::All;
 pub use append::Append;
 pub use collect::Collect;
 pub use drop::*;

--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -166,6 +166,32 @@ impl PipelineData {
             }
         }
     }
+
+    pub fn all<F>(
+        self,
+        mut f: F,
+        ctrlc: Option<Arc<AtomicBool>>,
+    ) -> Result<PipelineData, ShellError>
+    where
+        Self: Sized,
+        F: FnMut(Value) -> bool + 'static + Send,
+    {
+        let all_matches = match self {
+            PipelineData::Value(Value::List { vals, .. }) => Ok(vals
+                .into_iter()
+                .into_pipeline_data(ctrlc)
+                .into_iter()
+                .all(f)),
+            PipelineData::Stream(stream) => Ok(stream.into_pipeline_data(ctrlc).into_iter().all(f)),
+            PipelineData::Value(Value::Range { val, .. }) => match val.into_range_iter() {
+                Ok(iter) => Ok(iter.into_pipeline_data(ctrlc).into_iter().all(f)),
+                Err(error) => Err(error),
+            },
+            PipelineData::Value(v) => Ok(f(v)),
+        }?;
+
+        Ok(Value::from(all_matches).into_pipeline_data())
+    }
 }
 
 // impl Default for PipelineData {

--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -176,30 +176,6 @@ impl PipelineData {
             }
         }
     }
-
-    pub fn all<F>(
-        self,
-        mut f: F,
-        ctrlc: Option<Arc<AtomicBool>>,
-    ) -> Result<PipelineData, ShellError>
-    where
-        Self: Sized,
-        F: FnMut(Value) -> bool + 'static + Send,
-    {
-        let all_matches = match self {
-            PipelineData::Value(Value::List { vals, .. }) => {
-                Ok(vals.into_pipeline_data(ctrlc).into_iter().all(f))
-            }
-            PipelineData::Stream(stream) => Ok(stream.into_pipeline_data(ctrlc).into_iter().all(f)),
-            PipelineData::Value(Value::Range { val, .. }) => match val.into_range_iter() {
-                Ok(iter) => Ok(iter.into_pipeline_data(ctrlc).into_iter().all(f)),
-                Err(error) => Err(error),
-            },
-            PipelineData::Value(v) => Ok(f(v)),
-        }?;
-
-        Ok(all_matches.into_pipeline_data())
-    }
 }
 
 // impl Default for PipelineData {

--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -51,6 +51,16 @@ impl PipelineData {
         }
     }
 
+    pub fn into_interruptible_iter(self, ctrlc: Option<Arc<AtomicBool>>) -> PipelineIterator {
+        let mut iter = self.into_iter();
+
+        if let PipelineIterator(PipelineData::Stream(s)) = &mut iter {
+            s.ctrlc = ctrlc;
+        }
+
+        iter
+    }
+
     pub fn collect_string(self, separator: &str, config: &Config) -> String {
         match self {
             PipelineData::Value(v) => v.into_string(separator, config),

--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -114,13 +114,10 @@ impl PipelineData {
             PipelineData::Value(Value::Range { val, .. }) => {
                 Ok(val.into_range_iter()?.map(f).into_pipeline_data(ctrlc))
             }
-            PipelineData::Value(v) => {
-                let output = f(v);
-                match output {
-                    Value::Error { error } => Err(error),
-                    v => Ok(v.into_pipeline_data()),
-                }
-            }
+            PipelineData::Value(v) => match f(v) {
+                Value::Error { error } => Err(error),
+                v => Ok(v.into_pipeline_data()),
+            },
         }
     }
 
@@ -163,10 +160,9 @@ impl PipelineData {
                 Ok(vals.into_iter().filter(f).into_pipeline_data(ctrlc))
             }
             PipelineData::Stream(stream) => Ok(stream.filter(f).into_pipeline_data(ctrlc)),
-            PipelineData::Value(Value::Range { val, .. }) => match val.into_range_iter() {
-                Ok(iter) => Ok(iter.filter(f).into_pipeline_data(ctrlc)),
-                Err(error) => Err(error),
-            },
+            PipelineData::Value(Value::Range { val, .. }) => {
+                Ok(val.into_range_iter()?.filter(f).into_pipeline_data(ctrlc))
+            }
             PipelineData::Value(v) => {
                 if f(&v) {
                     Ok(v.into_pipeline_data())

--- a/crates/nu-protocol/src/value/from.rs
+++ b/crates/nu-protocol/src/value/from.rs
@@ -1,5 +1,14 @@
 use crate::{ShellError, Span, Value};
 
+impl From<bool> for Value {
+    fn from(val: bool) -> Self {
+        Value::Bool {
+            val,
+            span: Span::unknown(),
+        }
+    }
+}
+
 impl From<u8> for Value {
     fn from(val: u8) -> Self {
         Value::Int {


### PR DESCRIPTION
### Main changes

- Port the `all?` command from nushell

### Other changes

- Implement `From<bool>` for `Value, see 03667f3f.
- Add `PipelineData::into_iterruptible_iter` method, see 498079c9.
- Change `IntoPipelineData` and `IntoInterruptiblePipelineData` bounds to respectively accept `Into<Value>` and `IntoIterator`, see a1fd7077.

```rust
impl<V> IntoPipelineData for V
where
   V: Into<Value>,
{
    // --snip--
}

impl<I> IntoInterruptiblePipelineData for I
where
    I: IntoIterator + Send + 'static,
    I::IntoIter: Send + 'static,
    <I::IntoIter as Iterator>::Item: Into<Value>,
{
    // --snip--
}
```

