### PR TITLE
Move row condition to block

### DIFF
--- a/crates/nu-command/src/filters/where_.rs
+++ b/crates/nu-command/src/filters/where_.rs
@@ -1,4 +1,4 @@
-use nu_engine::eval_expression;
+use nu_engine::eval_block;
 use nu_protocol::ast::{Call, Expr, Expression};
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{Category, PipelineData, ShellError, Signature, SyntaxShape};
@@ -28,30 +28,34 @@ impl Command for Where {
         call: &Call,
         input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        let span = call.head;
         let cond = call.positional[0].clone();
 
         let ctrlc = engine_state.ctrlc.clone();
         let engine_state = engine_state.clone();
 
-        // FIXME: expensive
-        let mut stack = stack.clone();
-
-        let (var_id, cond) = match cond {
+        let block_id = match cond {
             Expression {
-                expr: Expr::RowCondition(var_id, expr),
+                expr: Expr::RowCondition(block_id),
                 ..
-            } => (var_id, expr),
+            } => block_id,
             _ => return Err(ShellError::InternalError("Expected row condition".into())),
         };
 
+        let block = engine_state.get_block(block_id).clone();
+        let mut stack = stack.collect_captures(&block.captures);
+
         input.filter(
             move |value| {
-                stack.add_var(var_id, value.clone());
-
-                let result = eval_expression(&engine_state, &mut stack, &cond);
+                if let Some(var) = block.signature.get_positional(0) {
+                    if let Some(var_id) = &var.var_id {
+                        stack.add_var(*var_id, value.clone());
+                    }
+                }
+                let result = eval_block(&engine_state, &mut stack, &block, PipelineData::new(span));
 
                 match result {
-                    Ok(result) => result.is_true(),
+                    Ok(result) => result.into_value(span).is_true(),
                     _ => false,
                 }
             },

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -228,7 +228,6 @@ pub fn eval_expression(
         Expr::ImportPattern(_) => Ok(Value::Nothing {
             span: Span::unknown(),
         }),
-        Expr::RowCondition(_, expr) => eval_expression(engine_state, stack, expr),
         Expr::Call(call) => {
             // FIXME: protect this collect with ctrl-c
             Ok(
@@ -277,7 +276,7 @@ pub fn eval_expression(
                 Operator::Pow => lhs.pow(op_span, &rhs),
             }
         }
-        Expr::Subexpression(block_id) => {
+        Expr::RowCondition(block_id) | Expr::Subexpression(block_id) => {
             let block = engine_state.get_block(*block_id);
 
             // FIXME: protect this collect with ctrl-c

--- a/crates/nu-parser/src/flatten.rs
+++ b/crates/nu-parser/src/flatten.rs
@@ -207,8 +207,7 @@ pub fn flatten_expression(
         Expr::String(_) => {
             vec![(expr.span, FlatShape::String)]
         }
-        Expr::RowCondition(_, expr) => flatten_expression(working_set, expr),
-        Expr::Subexpression(block_id) => {
+        Expr::RowCondition(block_id) | Expr::Subexpression(block_id) => {
             flatten_block(working_set, working_set.get_block(*block_id))
         }
         Expr::Table(headers, cells) => {

--- a/crates/nu-protocol/src/ast/expr.rs
+++ b/crates/nu-protocol/src/ast/expr.rs
@@ -17,7 +17,7 @@ pub enum Expr {
     Call(Box<Call>),
     ExternalCall(String, Span, Vec<Expression>),
     Operator(Operator),
-    RowCondition(VarId, Box<Expression>),
+    RowCondition(BlockId),
     BinaryOp(Box<Expression>, Box<Expression>, Box<Expression>), //lhs, op, rhs
     Subexpression(BlockId),
     Block(BlockId),

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -182,10 +182,9 @@ impl Expression {
                 }
                 false
             }
-            Expr::RowCondition(_, expr) => expr.has_in_variable(working_set),
             Expr::Signature(_) => false,
             Expr::String(_) => false,
-            Expr::Subexpression(block_id) => {
+            Expr::RowCondition(block_id) | Expr::Subexpression(block_id) => {
                 let block = working_set.get_block(*block_id);
 
                 if let Some(Statement::Pipeline(pipeline)) = block.stmts.get(0) {
@@ -311,10 +310,9 @@ impl Expression {
                     field_value.replace_in_variable(working_set, new_var_id);
                 }
             }
-            Expr::RowCondition(_, expr) => expr.replace_in_variable(working_set, new_var_id),
             Expr::Signature(_) => {}
             Expr::String(_) => {}
-            Expr::Subexpression(block_id) => {
+            Expr::RowCondition(block_id) | Expr::Subexpression(block_id) => {
                 let block = working_set.get_block(*block_id);
 
                 let new_expr = if let Some(Statement::Pipeline(pipeline)) = block.stmts.get(0) {


### PR DESCRIPTION
This allows row conditions to be blocks, and to also carry the row condition as a block instead of an expression. Moved `where` to use this new style.

Also randomly fixed `to json` which wasn't collecting before it was translating to json