### PR TITLE
enable env setting for prompt animation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -232,7 +232,8 @@ fn main() -> Result<()> {
 
             // Get animation milliseconds every loop, if not set, the animation
             // is defaulted to 1 second. If set to some non-number value,
-            // like "OFF", then the animation is disabled.
+            // like "OFF", then the animation is disabled. If set to some number
+            // like "5000" then the animation will run at 5 seconds.
             let animate_ms = match std::env::var("EQ_PROMPT_ANIMATE_MS") {
                 Ok(ms_str) => match ms_str.parse::<u64>() {
                     Ok(ms_int) => Some(ms_int),

--- a/src/main.rs
+++ b/src/main.rs
@@ -230,6 +230,15 @@ fn main() -> Result<()> {
             //Reset the ctrl-c handler
             ctrlc.store(false, Ordering::SeqCst);
 
+            // Get animation milliseconds every loop, if not set, return None to disable animation
+            let animate_ms = match std::env::var("EQ_PROMPT_ANIMATE_MS") {
+                Ok(ms_str) => match ms_str.parse::<u64>() {
+                    Ok(ms_int) => Some(ms_int),
+                    _ => None,
+                },
+                _ => None,
+            };
+
             let line_editor = Reedline::create()
                 .into_diagnostic()?
                 .with_completion_action_handler(Box::new(FuzzyCompletion {
@@ -238,6 +247,7 @@ fn main() -> Result<()> {
                 .with_highlighter(Box::new(NuHighlighter {
                     engine_state: engine_state.clone(),
                 }))
+                .with_repaint(animate_ms)
                 // .with_completion_action_handler(Box::new(
                 //     ListCompletionHandler::default().with_completer(Box::new(completer)),
                 // ))

--- a/src/main.rs
+++ b/src/main.rs
@@ -230,13 +230,15 @@ fn main() -> Result<()> {
             //Reset the ctrl-c handler
             ctrlc.store(false, Ordering::SeqCst);
 
-            // Get animation milliseconds every loop, if not set, return None to disable animation
+            // Get animation milliseconds every loop, if not set, the animation
+            // is defaulted to 1 second. If set to some non-number value,
+            // like "OFF", then the animation is disabled.
             let animate_ms = match std::env::var("EQ_PROMPT_ANIMATE_MS") {
                 Ok(ms_str) => match ms_str.parse::<u64>() {
                     Ok(ms_int) => Some(ms_int),
                     _ => None,
                 },
-                _ => None,
+                _ => Some(1000),
             };
 
             let line_editor = Reedline::create()


### PR DESCRIPTION
if `EQ_PROMPT_ANIMATION_MS` is set in your environment, such as `export EQ_PROMPT_ANIMATION="5000"`, then your prompt will animate every 5000 ms / 5 seconds. If it is unset then the animation will be set to the default 1000 ms / 1 sec. If it's set to some non-number like "OFF", then the animation will be disabled.