### PR TITLE
Fix busy poll with reedline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2125,7 +2125,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.2.0"
-source = "git+https://github.com/nushell/reedline?branch=main#75d9b4b52d0ea60334ef96d49cd00002acc5720c"
+source = "git+https://github.com/nushell/reedline?branch=main#2bc7046066f3d3f2a9a538fc3d546adf1e5d4b28"
 dependencies = [
  "chrono",
  "crossterm",

--- a/src/main.rs
+++ b/src/main.rs
@@ -230,16 +230,15 @@ fn main() -> Result<()> {
             //Reset the ctrl-c handler
             ctrlc.store(false, Ordering::SeqCst);
 
-            // Get animation milliseconds every loop, if not set, the animation
-            // is defaulted to 1 second. If set to some non-number value,
-            // like "OFF", then the animation is disabled. If set to some number
-            // like "5000" then the animation will run at 5 seconds.
-            let animate_ms = match std::env::var("EQ_PROMPT_ANIMATE_MS") {
-                Ok(ms_str) => match ms_str.parse::<u64>() {
-                    Ok(ms_int) => Some(ms_int),
-                    _ => None,
+            const EQ_PROMPT_ANIMATE_DEFAULT: bool = true;
+            // Toggle prompt animation
+            let animate = match std::env::var("EQ_PROMPT_ANIMATE") {
+                Ok(ms_str) => match ms_str.as_str() {
+                    "ON" | "1" => true,
+                    "OFF" | "0" => false,
+                    _ => EQ_PROMPT_ANIMATE_DEFAULT,
                 },
-                _ => Some(1000),
+                _ => EQ_PROMPT_ANIMATE_DEFAULT,
             };
 
             let line_editor = Reedline::create()
@@ -250,7 +249,7 @@ fn main() -> Result<()> {
                 .with_highlighter(Box::new(NuHighlighter {
                     engine_state: engine_state.clone(),
                 }))
-                .with_repaint(animate_ms)
+                .with_animation(animate)
                 // .with_completion_action_handler(Box::new(
                 //     ListCompletionHandler::default().with_completer(Box::new(completer)),
                 // ))


### PR DESCRIPTION
Fixes #386

Makes the changes to accept https://github.com/nushell/reedline/pull/188

Change CLI option `EQ_PROMPT_ANIMATE_MS` to binary `EQ_PROMPT_ANIMATE`
