### PR TITLE
added row_index coloring

### DIFF
--- a/crates/nu-command/src/viewers/color_config.rs
+++ b/crates/nu-command/src/viewers/color_config.rs
@@ -162,6 +162,7 @@ pub fn get_color_config(config: &Config) -> HashMap<String, Style> {
     hm.insert("nothing".to_string(), Color::White.normal());
     hm.insert("binary".to_string(), Color::White.normal());
     hm.insert("cellpath".to_string(), Color::White.normal());
+    hm.insert("row_index".to_string(), Color::Green.bold());
 
     for (key, value) in &config.color_config {
         update_hashmap(key, value, &mut hm);
@@ -369,11 +370,11 @@ fn test_hm() {
     hm.insert("primitive_range".to_string(), Color::White.normal());
     hm.insert("primitive_path".to_string(), Color::White.normal());
     hm.insert("primitive_binary".to_string(), Color::White.normal());
-    hm.insert("separator_color".to_string(), Color::White.normal());
+    hm.insert("separator".to_string(), Color::White.normal());
     hm.insert("header_align".to_string(), Color::Green.bold());
-    hm.insert("header_color".to_string(), Color::Green.bold());
+    hm.insert("header".to_string(), Color::Green.bold());
     hm.insert("header_style".to_string(), Style::default());
-    hm.insert("index_color".to_string(), Color::Green.bold());
+    hm.insert("row_index".to_string(), Color::Green.bold());
     hm.insert(
         "leading_trailing_space_bg".to_string(),
         Style::default().on(Color::Rgb(128, 128, 128)),

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -194,8 +194,8 @@ fn convert_to_table(
                                 StyledString {
                                     contents: y.1,
                                     style: TextStyle {
-                                        alignment: nu_table::Alignment::Center,
-                                        color_style: Some(color_hm["header"]),
+                                        alignment: nu_table::Alignment::Right,
+                                        color_style: Some(color_hm["row_index"]),
                                     },
                                 }
                             } else {

--- a/crates/nu-table/src/table.rs
+++ b/crates/nu-table/src/table.rs
@@ -640,7 +640,7 @@ impl WrappedTable {
         let column_count = self.column_widths.len();
         let mut output = String::new();
         let sep_color = color_hm
-            .get("separator_color")
+            .get("separator")
             .unwrap_or(&Style::default())
             .to_owned();
 
@@ -789,7 +789,7 @@ impl WrappedTable {
         color_hm: &HashMap<String, Style>,
     ) -> String {
         let sep_color = color_hm
-            .get("separator_color")
+            .get("separator")
             .unwrap_or(&Style::default())
             .to_owned();
 


### PR DESCRIPTION
add the ability to change the row index color via config with `color_config.row_index`.

note the yellow bold indexes.
![image](https://user-images.githubusercontent.com/343840/144258110-259f7fbc-e89c-4075-aa1b-9fbae1b9b435.png)

My current config.
```
let $config = {
  filesize_metric: $true
  table_mode: rounded
  use_ls_colors: $true
  color_config: {
    separator: yd
    leading_trailing_space_bg: white
    header: cb
    date: pu
    filesize: ub
    row_index: yb

    bool: red
    int: red
    duration: red
    range: red
    float: red
    #string: red
    nothing: red
    binary: red
    cellpath: red
  }
  use_grid_icons: $true
}
```

also, homogenized a coloring key.