### PR TITLE
add optional footer to table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1549,6 +1549,7 @@ version = "0.36.0"
 dependencies = [
  "ansi-cut",
  "nu-ansi-term 0.39.0",
+ "nu-protocol",
  "regex",
  "strip-ansi-escapes",
  "unicode-width",

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -1,3 +1,4 @@
+use super::color_config::style_primitive;
 use crate::viewers::color_config::get_color_config;
 use nu_protocol::ast::{Call, PathMember};
 use nu_protocol::engine::{Command, EngineState, Stack};
@@ -8,8 +9,6 @@ use nu_table::{StyledString, TextStyle, Theme};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use terminal_size::{Height, Width};
-
-use super::color_config::style_primitive;
 
 #[derive(Clone)]
 pub struct Table;
@@ -50,7 +49,7 @@ impl Command for Table {
                 let table = convert_to_table(vals, ctrlc, &config)?;
 
                 if let Some(table) = table {
-                    let result = nu_table::draw_table(&table, term_width, &color_hm);
+                    let result = nu_table::draw_table(&table, term_width, &color_hm, &config);
 
                     Ok(Value::String {
                         val: result,
@@ -65,7 +64,7 @@ impl Command for Table {
                 let table = convert_to_table(stream, ctrlc, &config)?;
 
                 if let Some(table) = table {
-                    let result = nu_table::draw_table(&table, term_width, &color_hm);
+                    let result = nu_table::draw_table(&table, term_width, &color_hm, &config);
 
                     Ok(Value::String {
                         val: result,
@@ -98,7 +97,7 @@ impl Command for Table {
                     theme: load_theme_from_config(&config),
                 };
 
-                let result = nu_table::draw_table(&table, term_width, &color_hm);
+                let result = nu_table::draw_table(&table, term_width, &color_hm, &config);
 
                 Ok(Value::String {
                     val: result,

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -9,6 +9,7 @@ pub struct Config {
     pub use_ls_colors: bool,
     pub color_config: HashMap<String, String>,
     pub use_grid_icons: bool,
+    pub footer_mode: FooterMode,
 }
 
 impl Default for Config {
@@ -19,8 +20,21 @@ impl Default for Config {
             use_ls_colors: true,
             color_config: HashMap::new(),
             use_grid_icons: false,
+            footer_mode: FooterMode::Never,
         }
     }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub enum FooterMode {
+    /// Never show the footer
+    Never,
+    /// Always show the footer
+    Always,
+    /// Only show the footer if there are more than RowCount rows
+    RowCount(u64),
+    /// Calculate the screen height, calculate row count, if display will be bigger than screen, add the footer
+    Auto,
 }
 
 impl Value {
@@ -50,6 +64,18 @@ impl Value {
                 }
                 "use_grid_icons" => {
                     config.use_grid_icons = value.as_bool()?;
+                }
+                "footer_mode" => {
+                    let val_str = value.as_string()?;
+                    config.footer_mode = match val_str.as_ref() {
+                        "auto" => FooterMode::Auto,
+                        "never" => FooterMode::Never,
+                        "always" => FooterMode::Always,
+                        _ => match &val_str.parse::<u64>() {
+                            Ok(number) => FooterMode::RowCount(*number),
+                            _ => FooterMode::Never,
+                        },
+                    };
                 }
                 _ => {}
             }

--- a/crates/nu-table/Cargo.toml
+++ b/crates/nu-table/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 [dependencies]
 # nu-ansi-term = "0.39.0"
 nu-ansi-term = { path = "../nu-ansi-term" }
+nu-protocol = { path = "../nu-protocol"}
 regex = "1.4"
 unicode-width = "0.1.8"
 strip-ansi-escapes = "0.1.1"

--- a/crates/nu-table/src/main.rs
+++ b/crates/nu-table/src/main.rs
@@ -1,3 +1,4 @@
+use nu_protocol::Config;
 use nu_table::{draw_table, StyledString, Table, TextStyle, Theme};
 use std::collections::HashMap;
 
@@ -25,8 +26,10 @@ fn main() {
     let table = Table::new(headers, vec![rows; 3], Theme::rounded());
     // FIXME: Config isn't available from here so just put these here to compile
     let color_hm: HashMap<String, nu_ansi_term::Style> = HashMap::new();
+    // get the default config
+    let config = Config::default();
     // Capture the table as a string
-    let output_table = draw_table(&table, width, &color_hm);
+    let output_table = draw_table(&table, width, &color_hm, &config);
     // Draw the table
     println!("{}", output_table)
 }

--- a/crates/nu-table/src/wrap.rs
+++ b/crates/nu-table/src/wrap.rs
@@ -24,13 +24,13 @@ pub struct Line {
     pub width: usize,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct WrappedLine {
     pub line: String,
     pub width: usize,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct WrappedCell {
     pub lines: Vec<WrappedLine>,
     pub max_width: usize,


### PR DESCRIPTION
This adds the ability to have an optional footer at the end of a table. The footer is a duplicate of the header. It can be configured by placing this in your `config.nu` file.
`  footer_mode: always`

The options are:
```rust
pub enum FooterMode {
    /// Never show the footer
    Never,
    /// Always show the footer
    Always,
    /// Only show the footer if there are more than RowCount rows
    RowCount(u64),
    /// Calculate the screen height, calculate row count, if display will be bigger than screen, add the footer
    Auto,
}
```
`Auto` is not implemented yet and is just ignored.

![image](https://user-images.githubusercontent.com/343840/144289388-8b6a9c37-ea32-4a2b-9b0c-3fb3663debba.png)
