### PR TITLE
Introduce metadata into the pipeline

### DIFF
--- a/crates/nu-command/src/core_commands/echo.rs
+++ b/crates/nu-command/src/core_commands/echo.rs
@@ -34,19 +34,22 @@ impl Command for Echo {
             let n = to_be_echoed.len();
             match n.cmp(&1usize) {
                 //  More than one value is converted in a stream of values
-                std::cmp::Ordering::Greater => PipelineData::Stream(ValueStream::from_stream(
-                    to_be_echoed.into_iter(),
-                    engine_state.ctrlc.clone(),
-                )),
+                std::cmp::Ordering::Greater => PipelineData::Stream(
+                    ValueStream::from_stream(to_be_echoed.into_iter(), engine_state.ctrlc.clone()),
+                    None,
+                ),
 
                 //  But a single value can be forwarded as it is
-                std::cmp::Ordering::Equal => PipelineData::Value(to_be_echoed[0].clone()),
+                std::cmp::Ordering::Equal => PipelineData::Value(to_be_echoed[0].clone(), None),
 
                 //  When there are no elements, we echo the empty string
-                std::cmp::Ordering::Less => PipelineData::Value(Value::String {
-                    val: "".to_string(),
-                    span: call.head,
-                }),
+                std::cmp::Ordering::Less => PipelineData::Value(
+                    Value::String {
+                        val: "".to_string(),
+                        span: call.head,
+                    },
+                    None,
+                ),
             }
         })
     }

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -74,8 +74,8 @@ impl Command for Each {
         let span = call.head;
 
         match input {
-            PipelineData::Value(Value::Range { .. })
-            | PipelineData::Value(Value::List { .. })
+            PipelineData::Value(Value::Range { .. }, ..)
+            | PipelineData::Value(Value::List { .. }, ..)
             | PipelineData::Stream { .. } => Ok(input
                 .into_iter()
                 .enumerate()
@@ -109,7 +109,7 @@ impl Command for Each {
                     }
                 })
                 .into_pipeline_data(ctrlc)),
-            PipelineData::Value(Value::Record { cols, vals, .. }) => {
+            PipelineData::Value(Value::Record { cols, vals, .. }, ..) => {
                 let mut output_cols = vec![];
                 let mut output_vals = vec![];
 
@@ -138,9 +138,12 @@ impl Command for Each {
                     }
 
                     match eval_block(&engine_state, &mut stack, block, PipelineData::new(span))? {
-                        PipelineData::Value(Value::Record {
-                            mut cols, mut vals, ..
-                        }) => {
+                        PipelineData::Value(
+                            Value::Record {
+                                mut cols, mut vals, ..
+                            },
+                            ..,
+                        ) => {
                             // TODO check that the lengths match when traversing record
                             output_cols.append(&mut cols);
                             output_vals.append(&mut vals);
@@ -159,7 +162,7 @@ impl Command for Each {
                 }
                 .into_pipeline_data())
             }
-            PipelineData::Value(x) => {
+            PipelineData::Value(x, ..) => {
                 let block = engine_state.get_block(block_id);
 
                 if let Some(var) = block.signature.get_positional(0) {

--- a/crates/nu-command/src/filters/length.rs
+++ b/crates/nu-command/src/filters/length.rs
@@ -26,7 +26,7 @@ impl Command for Length {
         input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
         match input {
-            PipelineData::Value(Value::Nothing { .. }) => Ok(Value::Int {
+            PipelineData::Value(Value::Nothing { .. }, ..) => Ok(Value::Int {
                 val: 0,
                 span: call.head,
             }

--- a/crates/nu-command/src/filters/lines.rs
+++ b/crates/nu-command/src/filters/lines.rs
@@ -34,7 +34,7 @@ impl Command for Lines {
             // Collect is needed because the string may not live long enough for
             // the Rc structure to continue using it. If split could take ownership
             // of the split values, then this wouldn't be needed
-            PipelineData::Value(Value::String { val, span }) => {
+            PipelineData::Value(Value::String { val, span }, ..) => {
                 let lines = val
                     .split(SPLIT_CHAR)
                     .map(|s| s.to_string())
@@ -50,7 +50,7 @@ impl Command for Lines {
 
                 Ok(iter.into_pipeline_data(engine_state.ctrlc.clone()))
             }
-            PipelineData::Stream(stream) => {
+            PipelineData::Stream(stream, ..) => {
                 let iter = stream
                     .into_iter()
                     .filter_map(|value| {
@@ -78,7 +78,7 @@ impl Command for Lines {
 
                 Ok(iter.into_pipeline_data(engine_state.ctrlc.clone()))
             }
-            PipelineData::Value(val) => Err(ShellError::UnsupportedInput(
+            PipelineData::Value(val, ..) => Err(ShellError::UnsupportedInput(
                 format!("Not supported input: {}", val.as_string()?),
                 call.head,
             )),

--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -57,7 +57,7 @@ impl Command for ParEach {
         let span = call.head;
 
         match input {
-            PipelineData::Value(Value::Range { val, .. }) => Ok(val
+            PipelineData::Value(Value::Range { val, .. }, ..) => Ok(val
                 .into_range_iter()?
                 .enumerate()
                 .par_bridge()
@@ -98,7 +98,7 @@ impl Command for ParEach {
                 .into_iter()
                 .flatten()
                 .into_pipeline_data(ctrlc)),
-            PipelineData::Value(Value::List { vals: val, .. }) => Ok(val
+            PipelineData::Value(Value::List { vals: val, .. }, ..) => Ok(val
                 .into_iter()
                 .enumerate()
                 .par_bridge()
@@ -139,7 +139,7 @@ impl Command for ParEach {
                 .into_iter()
                 .flatten()
                 .into_pipeline_data(ctrlc)),
-            PipelineData::Stream(stream) => Ok(stream
+            PipelineData::Stream(stream, ..) => Ok(stream
                 .enumerate()
                 .par_bridge()
                 .map(move |(idx, x)| {
@@ -179,7 +179,7 @@ impl Command for ParEach {
                 .into_iter()
                 .flatten()
                 .into_pipeline_data(ctrlc)),
-            PipelineData::Value(Value::Record { cols, vals, .. }) => {
+            PipelineData::Value(Value::Record { cols, vals, .. }, ..) => {
                 let mut output_cols = vec![];
                 let mut output_vals = vec![];
 
@@ -208,9 +208,12 @@ impl Command for ParEach {
                     }
 
                     match eval_block(&engine_state, &mut stack, block, PipelineData::new(span))? {
-                        PipelineData::Value(Value::Record {
-                            mut cols, mut vals, ..
-                        }) => {
+                        PipelineData::Value(
+                            Value::Record {
+                                mut cols, mut vals, ..
+                            },
+                            ..,
+                        ) => {
                             // TODO check that the lengths match when traversing record
                             output_cols.append(&mut cols);
                             output_vals.append(&mut vals);
@@ -229,7 +232,7 @@ impl Command for ParEach {
                 }
                 .into_pipeline_data())
             }
-            PipelineData::Value(x) => {
+            PipelineData::Value(x, ..) => {
                 let block = engine_state.get_block(block_id);
 
                 if let Some(var) = block.signature.get_positional(0) {

--- a/crates/nu-command/src/filters/range.rs
+++ b/crates/nu-command/src/filters/range.rs
@@ -90,7 +90,10 @@ impl Command for Range {
             };
 
             if from > to {
-                Ok(PipelineData::Value(Value::Nothing { span: call.head }))
+                Ok(PipelineData::Value(
+                    Value::Nothing { span: call.head },
+                    None,
+                ))
             } else {
                 let iter = v.into_iter().skip(from).take(to - from + 1);
                 Ok(iter.into_pipeline_data(engine_state.ctrlc.clone()))
@@ -100,7 +103,10 @@ impl Command for Range {
             let to = rows_to as usize;
 
             if from > to {
-                Ok(PipelineData::Value(Value::Nothing { span: call.head }))
+                Ok(PipelineData::Value(
+                    Value::Nothing { span: call.head },
+                    None,
+                ))
             } else {
                 let iter = input.into_iter().skip(from).take(to - from + 1);
                 Ok(iter.into_pipeline_data(engine_state.ctrlc.clone()))

--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -68,10 +68,13 @@ fn select(
     }
 
     match input {
-        PipelineData::Value(Value::List {
-            vals: input_vals,
-            span,
-        }) => {
+        PipelineData::Value(
+            Value::List {
+                vals: input_vals,
+                span,
+            },
+            ..,
+        ) => {
             let mut output = vec![];
 
             for input_val in input_vals {
@@ -92,7 +95,7 @@ fn select(
                 .into_iter()
                 .into_pipeline_data(engine_state.ctrlc.clone()))
         }
-        PipelineData::Stream(stream) => Ok(stream
+        PipelineData::Stream(stream, ..) => Ok(stream
             .map(move |x| {
                 let mut cols = vec![];
                 let mut vals = vec![];
@@ -113,7 +116,7 @@ fn select(
                 Value::Record { cols, vals, span }
             })
             .into_pipeline_data(engine_state.ctrlc.clone())),
-        PipelineData::Value(v) => {
+        PipelineData::Value(v, ..) => {
             let mut cols = vec![];
             let mut vals = vec![];
 

--- a/crates/nu-command/src/filters/wrap.rs
+++ b/crates/nu-command/src/filters/wrap.rs
@@ -35,7 +35,7 @@ impl Command for Wrap {
         let name: String = call.req(engine_state, stack, 0)?;
 
         match input {
-            PipelineData::Value(Value::List { vals, .. }) => Ok(vals
+            PipelineData::Value(Value::List { vals, .. }, ..) => Ok(vals
                 .into_iter()
                 .map(move |x| Value::Record {
                     cols: vec![name.clone()],
@@ -43,14 +43,14 @@ impl Command for Wrap {
                     span,
                 })
                 .into_pipeline_data(engine_state.ctrlc.clone())),
-            PipelineData::Stream(stream) => Ok(stream
+            PipelineData::Stream(stream, ..) => Ok(stream
                 .map(move |x| Value::Record {
                     cols: vec![name.clone()],
                     vals: vec![x],
                     span,
                 })
                 .into_pipeline_data(engine_state.ctrlc.clone())),
-            PipelineData::Value(input) => Ok(Value::Record {
+            PipelineData::Value(input, ..) => Ok(Value::Record {
                 cols: vec![name],
                 vals: vec![input],
                 span,

--- a/crates/nu-command/src/formats/from/eml.rs
+++ b/crates/nu-command/src/formats/from/eml.rs
@@ -230,10 +230,13 @@ fn from_eml(
         );
     }
 
-    Ok(PipelineData::Value(Value::from(Spanned {
-        item: collected,
-        span: head,
-    })))
+    Ok(PipelineData::Value(
+        Value::from(Spanned {
+            item: collected,
+            span: head,
+        }),
+        None,
+    ))
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/formats/from/ods.rs
+++ b/crates/nu-command/src/formats/from/ods.rs
@@ -194,7 +194,7 @@ fn from_ods(
         span: head,
     };
 
-    Ok(PipelineData::Value(record))
+    Ok(PipelineData::Value(record, None))
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/formats/from/url.rs
+++ b/crates/nu-command/src/formats/from/url.rs
@@ -67,11 +67,14 @@ fn from_url(input: PipelineData, head: Span, config: &Config) -> Result<Pipeline
                 vals.push(Value::String { val: v, span: head })
             }
 
-            Ok(PipelineData::Value(Value::Record {
-                cols,
-                vals,
-                span: head,
-            }))
+            Ok(PipelineData::Value(
+                Value::Record {
+                    cols,
+                    vals,
+                    span: head,
+                },
+                None,
+            ))
         }
         _ => Err(ShellError::UnsupportedInput(
             "String not compatible with url-encoding".to_string(),

--- a/crates/nu-command/src/formats/from/xlsx.rs
+++ b/crates/nu-command/src/formats/from/xlsx.rs
@@ -194,7 +194,7 @@ fn from_xlsx(
         span: head,
     };
 
-    Ok(PipelineData::Value(record))
+    Ok(PipelineData::Value(record, None))
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/math/eval.rs
+++ b/crates/nu-command/src/math/eval.rs
@@ -57,14 +57,14 @@ pub fn eval(
 ) -> Result<PipelineData, ShellError> {
     if let Some(expr) = spanned_expr {
         match parse(&expr.item, &expr.span) {
-            Ok(value) => Ok(PipelineData::Value(value)),
+            Ok(value) => Ok(PipelineData::Value(value, None)),
             Err(err) => Err(ShellError::UnsupportedInput(
                 format!("Math evaluation error: {}", err),
                 expr.span,
             )),
         }
     } else {
-        if let PipelineData::Value(Value::Nothing { .. }) = input {
+        if let PipelineData::Value(Value::Nothing { .. }, ..) = input {
             return Ok(input);
         }
         input.map(

--- a/crates/nu-command/src/math/utils.rs
+++ b/crates/nu-command/src/math/utils.rs
@@ -62,12 +62,12 @@ pub fn calculate(
     mf: impl Fn(&[Value], &Span) -> Result<Value, ShellError>,
 ) -> Result<Value, ShellError> {
     match values {
-        PipelineData::Stream(s) => helper_for_tables(&s.collect::<Vec<Value>>(), name, mf),
-        PipelineData::Value(Value::List { ref vals, .. }) => match &vals[..] {
+        PipelineData::Stream(s, ..) => helper_for_tables(&s.collect::<Vec<Value>>(), name, mf),
+        PipelineData::Value(Value::List { ref vals, .. }, ..) => match &vals[..] {
             [Value::Record { .. }, _end @ ..] => helper_for_tables(vals, name, mf),
             _ => mf(vals, &name),
         },
-        PipelineData::Value(Value::Record { vals, cols, span }) => {
+        PipelineData::Value(Value::Record { vals, cols, span }, ..) => {
             let new_vals: Result<Vec<Value>, ShellError> =
                 vals.into_iter().map(|val| mf(&[val], &name)).collect();
             match new_vals {
@@ -79,7 +79,7 @@ pub fn calculate(
                 Err(err) => Err(err),
             }
         }
-        PipelineData::Value(Value::Range { val, .. }) => {
+        PipelineData::Value(Value::Range { val, .. }, ..) => {
             let new_vals: Result<Vec<Value>, ShellError> = val
                 .into_range_iter()?
                 .map(|val| mf(&[val], &name))
@@ -87,6 +87,6 @@ pub fn calculate(
 
             mf(&new_vals?, &name)
         }
-        PipelineData::Value(val) => mf(&[val], &name),
+        PipelineData::Value(val, ..) => mf(&[val], &name),
     }
 }

--- a/crates/nu-command/src/random/bool.rs
+++ b/crates/nu-command/src/random/bool.rs
@@ -78,10 +78,13 @@ fn bool(
     let mut rng = thread_rng();
     let bool_result: bool = rng.gen_bool(probability);
 
-    Ok(PipelineData::Value(Value::Bool {
-        val: bool_result,
-        span,
-    }))
+    Ok(PipelineData::Value(
+        Value::Bool {
+            val: bool_result,
+            span,
+        },
+        None,
+    ))
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/random/chars.rs
+++ b/crates/nu-command/src/random/chars.rs
@@ -70,10 +70,13 @@ fn chars(
         .map(char::from)
         .collect::<String>();
 
-    Ok(PipelineData::Value(Value::String {
-        val: random_string,
-        span,
-    }))
+    Ok(PipelineData::Value(
+        Value::String {
+            val: random_string,
+            span,
+        },
+        None,
+    ))
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/strings/format/command.rs
+++ b/crates/nu-command/src/strings/format/command.rs
@@ -125,7 +125,10 @@ fn format(
     //  We can only handle a Record or a List of Record's
     match data_as_value {
         Value::Record { .. } => match format_record(format_operations, &data_as_value) {
-            Ok(value) => Ok(PipelineData::Value(Value::string(value, Span::unknown()))),
+            Ok(value) => Ok(PipelineData::Value(
+                Value::string(value, Span::unknown()),
+                None,
+            )),
             Err(value) => Err(value),
         },
 
@@ -151,10 +154,10 @@ fn format(
                 }
             }
 
-            Ok(PipelineData::Stream(ValueStream::from_stream(
-                list.into_iter(),
+            Ok(PipelineData::Stream(
+                ValueStream::from_stream(list.into_iter(), None),
                 None,
-            )))
+            ))
         }
         _ => Err(ShellError::UnsupportedInput(
             "Input data is not supported by this command.".to_string(),

--- a/crates/nu-command/src/strings/parse.rs
+++ b/crates/nu-command/src/strings/parse.rs
@@ -74,6 +74,7 @@ fn operate(
     let head = call.head;
     let pattern: Spanned<String> = call.req(engine_state, stack, 0)?;
     let regex: bool = call.has_flag("regex");
+    let ctrlc = engine_state.ctrlc.clone();
 
     let pattern_item = pattern.item;
     let pattern_span = pattern.span;
@@ -125,10 +126,10 @@ fn operate(
         }
     }
 
-    Ok(PipelineData::Stream(ValueStream::from_stream(
-        parsed.into_iter(),
+    Ok(PipelineData::Stream(
+        ValueStream::from_stream(parsed.into_iter(), ctrlc),
         None,
-    )))
+    ))
 }
 
 fn build_regex(input: &str, span: Span) -> Result<String, ShellError> {

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -94,7 +94,7 @@ impl ExternalCommand {
 
         // If there is an input from the pipeline. The stdin from the process
         // is piped so it can be used to send the input information
-        if !matches!(input, PipelineData::Value(Value::Nothing { .. })) {
+        if !matches!(input, PipelineData::Value(Value::Nothing { .. }, ..)) {
             process.stdin(Stdio::piped());
         }
 

--- a/crates/nu-command/src/viewers/griddle.rs
+++ b/crates/nu-command/src/viewers/griddle.rs
@@ -64,7 +64,7 @@ prints out the list properly."#
         let use_grid_icons = config.use_grid_icons;
 
         match input {
-            PipelineData::Value(Value::List { vals, .. }) => {
+            PipelineData::Value(Value::List { vals, .. }, ..) => {
                 // dbg!("value::list");
                 let data = convert_to_list(vals, &config);
                 if let Some(items) = data {
@@ -81,7 +81,7 @@ prints out the list properly."#
                     Ok(PipelineData::new(call.head))
                 }
             }
-            PipelineData::Stream(stream) => {
+            PipelineData::Stream(stream, ..) => {
                 // dbg!("value::stream");
                 let data = convert_to_list(stream, &config);
                 if let Some(items) = data {
@@ -99,7 +99,7 @@ prints out the list properly."#
                     Ok(PipelineData::new(call.head))
                 }
             }
-            PipelineData::Value(Value::Record { cols, vals, .. }) => {
+            PipelineData::Value(Value::Record { cols, vals, .. }, ..) => {
                 // dbg!("value::record");
                 let mut items = vec![];
 

--- a/crates/nu-plugin/src/plugin.rs
+++ b/crates/nu-plugin/src/plugin.rs
@@ -164,8 +164,8 @@ impl Command for PluginDeclaration {
             .map_err(|err| ShellError::PluginError(format!("{}", err)))?;
 
         let input = match input {
-            PipelineData::Value(value) => value,
-            PipelineData::Stream(stream) => {
+            PipelineData::Value(value, ..) => value,
+            PipelineData::Stream(stream, ..) => {
                 let values = stream.collect::<Vec<Value>>();
 
                 Value::List {
@@ -199,7 +199,9 @@ impl Command for PluginDeclaration {
                 .map_err(|err| ShellError::PluginError(err.to_string()))?;
 
             match response {
-                PluginResponse::Value(value) => Ok(PipelineData::Value(value.as_ref().clone())),
+                PluginResponse::Value(value) => {
+                    Ok(PipelineData::Value(value.as_ref().clone(), None))
+                }
                 PluginResponse::Error(msg) => Err(PluginError::DecodingError(msg)),
                 _ => Err(PluginError::DecodingError(
                     "result value from plugin not found".into(),

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -362,8 +362,8 @@ impl EngineState {
         let decl = self.get_decl(decl_id);
 
         match input {
-            PipelineData::Stream(_) => decl,
-            PipelineData::Value(value) => match value {
+            PipelineData::Stream(..) => decl,
+            PipelineData::Value(value, ..) => match value {
                 Value::CustomValue { val, .. } => {
                     // This filter works because the custom definitions were declared
                     // before the default nushell declarations. This means that the custom

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ use nu_parser::parse;
 use nu_protocol::{
     ast::Call,
     engine::{EngineState, Stack, StateWorkingSet},
-    IntoPipelineData, PipelineData, ShellError, Span, Value, CONFIG_VARIABLE_ID,
+    PipelineData, ShellError, Span, Value, CONFIG_VARIABLE_ID,
 };
 use reedline::{Completer, CompletionActionHandler, DefaultPrompt, LineBuffer, Prompt};
 
@@ -310,8 +310,8 @@ fn main() -> Result<()> {
     }
 }
 
-fn print_value(
-    value: Value,
+fn print_pipeline_data(
+    input: PipelineData,
     engine_state: &EngineState,
     stack: &mut Stack,
 ) -> Result<(), ShellError> {
@@ -322,15 +322,13 @@ fn print_value(
 
     let output = match engine_state.find_decl("table".as_bytes()) {
         Some(decl_id) => {
-            let table = engine_state.get_decl(decl_id).run(
-                engine_state,
-                stack,
-                &Call::new(),
-                value.into_pipeline_data(),
-            )?;
+            let table =
+                engine_state
+                    .get_decl(decl_id)
+                    .run(engine_state, stack, &Call::new(), input)?;
             table.collect_string("\n", &config)
         }
-        None => value.into_string(", ", &config),
+        None => input.collect_string(", ", &config),
     };
     let stdout = std::io::stdout();
 
@@ -427,11 +425,7 @@ fn eval_source(
         PipelineData::new(Span::unknown()),
     ) {
         Ok(pipeline_data) => {
-            if let Err(err) = print_value(
-                pipeline_data.into_value(Span::unknown()),
-                engine_state,
-                stack,
-            ) {
+            if let Err(err) = print_pipeline_data(pipeline_data, engine_state, stack) {
                 let working_set = StateWorkingSet::new(engine_state);
 
                 report_error(&working_set, &err);


### PR DESCRIPTION
This adds metadata to `PipelineData`, which is currently only used for `ls`.  This moves the styling of `ls` output to much later (currently `table`)