### PR TITLE
Refactor and fix parsing of plugins a bit

### DIFF
--- a/crates/nu-parser/src/lib.rs
+++ b/crates/nu-parser/src/lib.rs
@@ -16,4 +16,4 @@ pub use parse_keywords::{
 pub use parser::{find_captures_in_expr, parse, Import};
 
 #[cfg(feature = "plugin")]
-pub use parse_keywords::parse_plugin;
+pub use parse_keywords::parse_register;

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -1087,7 +1087,7 @@ pub fn parse_source(
 }
 
 #[cfg(feature = "plugin")]
-pub fn parse_plugin(
+pub fn parse_register(
     working_set: &mut StateWorkingSet,
     spans: &[Span],
 ) -> (Statement, Option<ParseError>) {
@@ -1131,8 +1131,10 @@ pub fn parse_plugin(
                                         let plugin_decl =
                                             PluginDeclaration::new(filename.clone(), signature);
 
-                                        working_set.add_plugin_decl(Box::new(plugin_decl));
+                                        working_set.add_decl(Box::new(plugin_decl));
                                     }
+
+                                    working_set.mark_plugins_file_dirty();
 
                                     None
                                 }
@@ -1151,7 +1153,8 @@ pub fn parse_plugin(
                     if let Ok(filename) = String::from_utf8(filename.to_vec()) {
                         if let Ok(signature) = serde_json::from_slice::<Signature>(signature) {
                             let plugin_decl = PluginDeclaration::new(filename, signature);
-                            working_set.add_plugin_decl(Box::new(plugin_decl));
+                            working_set.add_decl(Box::new(plugin_decl));
+                            working_set.mark_plugins_file_dirty();
 
                             None
                         } else {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -23,7 +23,7 @@ use crate::parse_keywords::{
 use std::collections::HashSet;
 
 #[cfg(feature = "plugin")]
-use crate::parse_keywords::parse_plugin;
+use crate::parse_keywords::parse_register;
 
 #[derive(Debug, Clone)]
 pub enum Import {}
@@ -3226,7 +3226,7 @@ pub fn parse_statement(
         ),
         b"hide" => parse_hide(working_set, spans),
         #[cfg(feature = "plugin")]
-        b"register" => parse_plugin(working_set, spans),
+        b"register" => parse_register(working_set, spans),
         _ => {
             let (expr, err) = parse_expression(working_set, spans, true);
             (Statement::Pipeline(Pipeline::from_vec(vec![expr])), err)

--- a/crates/nu-protocol/src/engine/command.rs
+++ b/crates/nu-protocol/src/engine/command.rs
@@ -46,7 +46,7 @@ pub trait Command: Send + Sync + CommandClone {
         self.name().contains(' ')
     }
 
-    // Is a plugin command
+    // Is a plugin command (returns plugin's name if yes)
     fn is_plugin(&self) -> Option<&str> {
         None
     }


### PR DESCRIPTION
1. Fixes adding the plugin decls into the engine state so that they are usable immediately.

This works now but didn't previously:
```
> register /path/to/nu_plugin_inc; 2 | inc
```

2. Fixes duplicate signatures in plugin.nu
3. Misc small fixes to naming etc.
4. TODO: Fix duplicate entries in `help commands` 