### PR TITLE
Add canonicalization to parser paths; Improve FileNotFound error

### DIFF
--- a/crates/nu-parser/src/errors.rs
+++ b/crates/nu-parser/src/errors.rs
@@ -187,7 +187,7 @@ pub enum ParseError {
     #[diagnostic(code(nu::parser::export_not_found), url(docsrs))]
     ExportNotFound(#[label = "could not find imports"] Span),
 
-    #[error("File not found")]
+    #[error("File not found: {0}")]
     #[diagnostic(code(nu::parser::file_not_found), url(docsrs))]
     FileNotFound(String),
 

--- a/crates/nu-protocol/src/ast/import_pattern.rs
+++ b/crates/nu-protocol/src/ast/import_pattern.rs
@@ -24,6 +24,17 @@ pub struct ImportPattern {
 }
 
 impl ImportPattern {
+    pub fn new() -> Self {
+        ImportPattern {
+            head: ImportPatternHead {
+                name: vec![],
+                span: Span::unknown(),
+            },
+            members: vec![],
+            hidden: HashSet::new(),
+        }
+    }
+
     pub fn span(&self) -> Span {
         let mut spans = vec![self.head.span];
 
@@ -48,5 +59,11 @@ impl ImportPattern {
             members: self.members,
             hidden,
         }
+    }
+}
+
+impl Default for ImportPattern {
+    fn default() -> Self {
+        Self::new()
     }
 }


### PR DESCRIPTION
* `source` and `use` canonicalize their path which should make them easier to use
* Added file path print to FileNotFound error