### PR TITLE
this fixes garbage ansi when externals turn off vt processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,6 +711,7 @@ version = "0.1.0"
 dependencies = [
  "assert_cmd",
  "crossterm",
+ "crossterm_winapi",
  "ctrlc",
  "dialoguer",
  "miette",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ nu-term-grid = { path = "./crates/nu-term-grid" }
 nu-ansi-term = { path = "./crates/nu-ansi-term" }
 miette = "3.0.0"
 ctrlc = "3.2.1"
-# mimalloc = { version = "*", default-features = false }
 crossterm_winapi = "0.9.0"
+# mimalloc = { version = "*", default-features = false }
 
 [features]
 plugin = ["nu-plugin", "nu-parser/plugin", "nu-command/plugin", "nu-protocol/plugin", "nu-engine/plugin"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ nu-ansi-term = { path = "./crates/nu-ansi-term" }
 miette = "3.0.0"
 ctrlc = "3.2.1"
 # mimalloc = { version = "*", default-features = false }
+crossterm_winapi = "0.9.0"
 
 [features]
 plugin = ["nu-plugin", "nu-parser/plugin", "nu-command/plugin", "nu-protocol/plugin", "nu-engine/plugin"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -463,16 +463,56 @@ fn eval_source(
                 let working_set = StateWorkingSet::new(engine_state);
 
                 report_error(&working_set, &err);
+
+                // reset vt processing, aka ansi because illbehaved externals can break it
+                #[cfg(windows)]
+                {
+                    let _ = enable_vt_processing();
+                }
+
                 return false;
+            }
+
+            // reset vt processing, aka ansi because illbehaved externals can break it
+            #[cfg(windows)]
+            {
+                let _ = enable_vt_processing();
             }
         }
         Err(err) => {
             let working_set = StateWorkingSet::new(engine_state);
 
             report_error(&working_set, &err);
+
+            // reset vt processing, aka ansi because illbehaved externals can break it
+            #[cfg(windows)]
+            {
+                let _ = enable_vt_processing();
+            }
             return false;
         }
     }
 
     true
+}
+
+fn enable_vt_processing() -> Result<(), ShellError> {
+    pub const ENABLE_PROCESSED_OUTPUT: u32 = 0x0001;
+    pub const ENABLE_VIRTUAL_TERMINAL_PROCESSING: u32 = 0x0004;
+    // let mask = ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+    use crossterm_winapi::{ConsoleMode, Handle};
+
+    let console_mode = ConsoleMode::from(Handle::current_out_handle()?);
+    let old_mode = console_mode.mode()?;
+
+    // researching odd ansi behavior in windows terminal repo revealed that
+    // enable_processed_output and enable_virtual_terminal_processing should be used
+    // also, instead of checking old_mode & mask, just set the mode already
+
+    // if old_mode & mask == 0 {
+    console_mode
+        .set_mode(old_mode | ENABLE_PROCESSED_OUTPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING)?;
+    // }
+
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,4 @@
-use std::{
-    io::Write,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
-};
-
+use crossterm_winapi::{ConsoleMode, Handle};
 use dialoguer::{
     console::{Style, Term},
     theme::ColorfulTheme,
@@ -22,6 +15,13 @@ use nu_protocol::{
     PipelineData, ShellError, Span, Value, CONFIG_VARIABLE_ID,
 };
 use reedline::{Completer, CompletionActionHandler, DefaultPrompt, LineBuffer, Prompt};
+use std::{
+    io::Write,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
 
 #[cfg(feature = "plugin")]
 use nu_plugin::plugin::eval_plugin_signatures;
@@ -500,7 +500,6 @@ fn enable_vt_processing() -> Result<(), ShellError> {
     pub const ENABLE_PROCESSED_OUTPUT: u32 = 0x0001;
     pub const ENABLE_VIRTUAL_TERMINAL_PROCESSING: u32 = 0x0004;
     // let mask = ENABLE_VIRTUAL_TERMINAL_PROCESSING;
-    use crossterm_winapi::{ConsoleMode, Handle};
 
     let console_mode = ConsoleMode::from(Handle::current_out_handle()?);
     let old_mode = console_mode.mode()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#[cfg(windows)]
+#[cfg(windows)]
 use crossterm_winapi::{ConsoleMode, Handle};
 use dialoguer::{
     console::{Style, Term},
@@ -496,6 +498,7 @@ fn eval_source(
     true
 }
 
+#[cfg(windows)]
 fn enable_vt_processing() -> Result<(), ShellError> {
     pub const ENABLE_PROCESSED_OUTPUT: u32 = 0x0001;
     pub const ENABLE_VIRTUAL_TERMINAL_PROCESSING: u32 = 0x0004;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 #[cfg(windows)]
-#[cfg(windows)]
 use crossterm_winapi::{ConsoleMode, Handle};
 use dialoguer::{
     console::{Style, Term},


### PR DESCRIPTION
some illbehaved externals turn off `ENABLE_VIRTUAL_TERMINAL_PROCESSING` in windows. This reset that mode.

before:
![image](https://user-images.githubusercontent.com/343840/144657475-9a84dbc5-3ebf-4c6c-8fcf-48832680d513.png)

after:
![image](https://user-images.githubusercontent.com/343840/144657552-c01fce1c-3fc2-412f-9d32-3980661cc744.png)
