### PR TITLE
allow decimals/floats to be formatted with precision

### DIFF
--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -216,6 +216,8 @@ fn convert_to_table(
     config: &Config,
 ) -> Result<Option<nu_table::Table>, ShellError> {
     let mut iter = iter.into_iter().peekable();
+    let color_hm = get_color_config(config);
+    let float_precision = config.float_precision as usize;
 
     if let Some(first) = iter.peek() {
         let mut headers = first.columns();
@@ -268,7 +270,6 @@ fn convert_to_table(
             data.push(row);
         }
 
-        let color_hm = get_color_config(config);
         Ok(Some(nu_table::Table {
             headers: headers
                 .into_iter()
@@ -294,6 +295,17 @@ fn convert_to_table(
                                         color_style: Some(color_hm["row_index"]),
                                     },
                                 }
+                            } else if &y.0 == "float" {
+                                // set dynamic precision from config
+                                let precise_number =
+                                    match convert_with_precision(&y.1, float_precision) {
+                                        Ok(num) => num,
+                                        Err(e) => e.to_string(),
+                                    };
+                                StyledString {
+                                    contents: precise_number,
+                                    style: style_primitive(&y.0, &color_hm),
+                                }
                             } else {
                                 StyledString {
                                     contents: y.1,
@@ -309,6 +321,20 @@ fn convert_to_table(
     } else {
         Ok(None)
     }
+}
+
+fn convert_with_precision(val: &str, precision: usize) -> Result<String, ShellError> {
+    // vall will always be a f64 so convert it with precision formatting
+    let val_float = match val.parse::<f64>() {
+        Ok(f) => f,
+        Err(e) => {
+            return Err(ShellError::LabeledError(
+                "error converting string to f64".to_string(),
+                e.to_string(),
+            ));
+        }
+    };
+    Ok(format!("{:.prec$}", val_float, prec = precision))
 }
 
 struct PagingTableCreator {

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -325,11 +325,11 @@ fn convert_to_table(
 
 fn convert_with_precision(val: &str, precision: usize) -> Result<String, ShellError> {
     // vall will always be a f64 so convert it with precision formatting
-    let val_float = match val.parse::<f64>() {
+    let val_float = match val.trim().parse::<f64>() {
         Ok(f) => f,
         Err(e) => {
             return Err(ShellError::LabeledError(
-                "error converting string to f64".to_string(),
+                format!("error converting string [{}] to f64", &val),
                 e.to_string(),
             ));
         }

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -13,6 +13,7 @@ pub struct Config {
     pub use_grid_icons: bool,
     pub footer_mode: FooterMode,
     pub animate_prompt: bool,
+    pub float_precision: i64,
 }
 
 impl Default for Config {
@@ -25,6 +26,7 @@ impl Default for Config {
             use_grid_icons: false,
             footer_mode: FooterMode::Never,
             animate_prompt: ANIMATE_PROMPT_DEFAULT,
+            float_precision: 4,
         }
     }
 }
@@ -83,8 +85,11 @@ impl Value {
                 }
                 "animate_prompt" => {
                     let val = value.as_bool()?;
-
                     config.animate_prompt = val;
+                }
+                "float_precision" => {
+                    let val = value.as_integer()?;
+                    config.float_precision = val;
                 }
                 _ => {}
             }


### PR DESCRIPTION
with a new config flag you can set the float/decimal precision in tables?
```
let $config = {
  float_precision: 2
}
```
![image](https://user-images.githubusercontent.com/343840/145063610-b15822cd-1d6c-4991-b71c-0e4dd03ac746.png)

```
let $config = {
  float_precision: 10
}
```
![image](https://user-images.githubusercontent.com/343840/145063715-a3205d63-290e-4254-8076-038622534b80.png)
