### PR TITLE
optionally remove table output color

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1642,6 +1642,7 @@ name = "nu-table"
 version = "0.36.0"
 dependencies = [
  "ansi-cut",
+ "atty",
  "nu-ansi-term 0.39.0",
  "nu-protocol",
  "regex",

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -14,6 +14,7 @@ pub struct Config {
     pub footer_mode: FooterMode,
     pub animate_prompt: bool,
     pub float_precision: i64,
+    pub without_color: bool,
 }
 
 impl Default for Config {
@@ -27,6 +28,7 @@ impl Default for Config {
             footer_mode: FooterMode::Never,
             animate_prompt: ANIMATE_PROMPT_DEFAULT,
             float_precision: 4,
+            without_color: false,
         }
     }
 }
@@ -84,12 +86,13 @@ impl Value {
                     };
                 }
                 "animate_prompt" => {
-                    let val = value.as_bool()?;
-                    config.animate_prompt = val;
+                    config.animate_prompt = value.as_bool()?;
                 }
                 "float_precision" => {
-                    let val = value.as_integer()?;
-                    config.float_precision = val;
+                    config.float_precision = value.as_integer()?;
+                }
+                "without_color" => {
+                    config.without_color = value.as_bool()?;
                 }
                 _ => {}
             }

--- a/crates/nu-table/Cargo.toml
+++ b/crates/nu-table/Cargo.toml
@@ -12,10 +12,10 @@ name = "table"
 path = "src/main.rs"
 
 [dependencies]
-# nu-ansi-term = "0.39.0"
 nu-ansi-term = { path = "../nu-ansi-term" }
 nu-protocol = { path = "../nu-protocol"}
 regex = "1.4"
 unicode-width = "0.1.8"
 strip-ansi-escapes = "0.1.1"
 ansi-cut = "0.1.1"
+atty = "0.2.14"


### PR DESCRIPTION
this is one step toward allowing nushell/engine-q to be configured to not use ansi color output.

With this setting in your `config.nu` file you can remove table coloring.
```
let $config = {
  without_color: $true
}
```
note: the `ls` is still colored. we can try to change the command line syntax highlighting in another PR.
`without_color` defaults to `false`

![image](https://user-images.githubusercontent.com/343840/145417568-c2de66eb-096e-418e-8cd8-700c0fd5f921.png)

this PR also restored the ability to use detect ttys and use color appropriately. as I recall, one can do `ls` from vim and color is not wanted there.
