### PR TITLE
update to latest reedline, change config point name, enable output without ansi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2368,12 +2368,13 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.2.0"
-source = "git+https://github.com/nushell/reedline?branch=main#2bc7046066f3d3f2a9a538fc3d546adf1e5d4b28"
+source = "git+https://github.com/nushell/reedline?branch=main#6884ec4062a1b2184a6d47553101d3575d4e8b61"
 dependencies = [
  "chrono",
  "crossterm",
  "nu-ansi-term 0.39.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
+ "strip-ansi-escapes",
  "unicode-segmentation",
  "unicode-width",
 ]

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -15,7 +15,7 @@ pub struct Config {
     pub animate_prompt: bool,
     pub float_precision: i64,
     pub filesize_format: String,
-    pub without_color: bool,
+    pub use_ansi_coloring: bool,
 }
 
 impl Default for Config {
@@ -30,7 +30,7 @@ impl Default for Config {
             animate_prompt: ANIMATE_PROMPT_DEFAULT,
             float_precision: 4,
             filesize_format: "auto".into(),
-            without_color: false,
+            use_ansi_coloring: true,
         }
     }
 }
@@ -93,8 +93,8 @@ impl Value {
                 "float_precision" => {
                     config.float_precision = value.as_integer()?;
                 }
-                "without_color" => {
-                    config.without_color = value.as_bool()?;
+                "use_ansi_coloring" => {
+                    config.use_ansi_coloring = value.as_bool()?;
                 }
                 "filesize_format" => {
                     config.filesize_format = value.as_string()?.to_lowercase();

--- a/crates/nu-table/src/table.rs
+++ b/crates/nu-table/src/table.rs
@@ -954,7 +954,7 @@ impl WrappedTable {
         }
 
         // the atty is for when people do ls from vim, there should be no coloring there
-        if config.without_color || !atty::is(atty::Stream::Stdout) {
+        if !config.use_ansi_coloring || !atty::is(atty::Stream::Stdout) {
             // Draw the table without ansi colors
             if let Ok(bytes) = strip_ansi_escapes::strip(&output) {
                 String::from_utf8_lossy(&bytes).to_string()

--- a/src/main.rs
+++ b/src/main.rs
@@ -309,7 +309,10 @@ fn main() -> Result<()> {
                 // ))
                 .with_validator(Box::new(NuValidator {
                     engine_state: engine_state.clone(),
-                }));
+                }))
+                .with_ansi_colors(config.use_ansi_coloring);
+            //FIXME: if config.use_ansi_coloring is false then we should
+            // turn off the hinter but I don't see any way to do that yet.
 
             let mut line_editor = if let Some(history_path) = history_path.clone() {
                 line_editor


### PR DESCRIPTION
the changes that were made to reedline allow the prompt, the syntax highlighting and the hinter to be rendered without ansi colors.

<img width="578" alt="Screen Shot 2021-12-09 at 3 35 17 PM" src="https://user-images.githubusercontent.com/343840/145479546-3ac11b20-cec8-47db-9bea-30b4b1b87dbb.png">

remaining todo in the next pr
- [ ] figure out how to disable hinter because it may look weird this hints the same color as the text?
- [ ] figure out how to disable dialoguer colors
