### PR TITLE
Add zip-support to extra

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ extra = [
 	"default",
 	"dataframe",
 	"gstat",
+	"zip-support",
 ]
 
 wasi = ["inc"]


### PR DESCRIPTION
As @fdncred pointed out in my last PR related to the port of `to-md` and `to-html`, the zip support that i added only worked if you did `cargo run --all-features` now it works also if you use `cargo run --features=extra`.