### PR TITLE
tweak `version` output as a list vs table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,6 +1210,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
 
 [[package]]
+name = "is_debug"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06d198e9919d9822d5f7083ba8530e04de87841eaf21ead9af8f2304efd57c89"
+
+[[package]]
 name = "itertools"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1684,6 +1690,7 @@ dependencies = [
  "serde_urlencoded",
  "serde_yaml",
  "sha2",
+ "shadow-rs",
  "strip-ansi-escapes",
  "sysinfo",
  "terminal_size",
@@ -2712,6 +2719,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "shadow-rs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8935e920eb80ff8f5a5bced990325d12f6cc1015154a3852c6a23cf5bd71c447"
+dependencies = [
+ "chrono",
+ "git2",
+ "is_debug",
 ]
 
 [[package]]

--- a/crates/nu-command/src/core_commands/version.rs
+++ b/crates/nu-command/src/core_commands/version.rs
@@ -188,31 +188,6 @@ pub fn version(
         },
     );
 
-    // Manually create a list of all possible plugin names
-    // Don't think we need this anymore. Leaving it here, just in case we do actually need it.
-    // let all_plugins = vec![
-    //     "fetch",
-    //     "inc",
-    //     "match",
-    //     "post",
-    //     "ps",
-    //     "sys",
-    //     "textview",
-    //     "binaryview",
-    //     "chart bar",
-    //     "chart line",
-    //     "from bson",
-    //     "from sqlite",
-    //     "query json",
-    //     "s3",
-    //     "selector",
-    //     "start",
-    //     "to bson",
-    //     "to sqlite",
-    //     "tree",
-    //     "xpath",
-    // ];
-
     // Get a list of command names and check for plugins
     let installed_plugins = engine_state
         .plugin_decls()
@@ -232,12 +207,20 @@ pub fn version(
     let cols = indexmap.keys().cloned().collect::<Vec<_>>();
     let vals = indexmap.values().cloned().collect::<Vec<_>>();
 
-    Ok(Value::List {
-        vals: vec![Value::Record {
-            cols,
-            vals,
-            span: Span::unknown(),
-        }],
+    // Ok(Value::List {
+    //     vals: vec![Value::Record {
+    //         cols,
+    //         vals,
+    //         span: Span::unknown(),
+    //     }],
+    //     span: Span::unknown(),
+    // }
+    // .into_pipeline_data())
+
+    // List looks better than table, imo
+    Ok(Value::Record {
+        cols,
+        vals,
         span: Span::unknown(),
     }
     .into_pipeline_data())


### PR DESCRIPTION
I just think it looks better this way.

<img width="725" alt="Screen Shot 2021-12-11 at 2 18 28 PM" src="https://user-images.githubusercontent.com/343840/145690465-b0654e08-3d21-468b-993c-f5f20263e264.png">
