### PR TITLE
Fix hiding of import patterns with globs

### DIFF
--- a/crates/nu-command/src/core_commands/hide.rs
+++ b/crates/nu-command/src/core_commands/hide.rs
@@ -59,9 +59,7 @@ impl Command for Hide {
                 overlay.env_vars_with_head(&import_pattern.head.name)
             } else {
                 match &import_pattern.members[0] {
-                    ImportPatternMember::Glob { .. } => {
-                        overlay.env_vars_with_head(&import_pattern.head.name)
-                    }
+                    ImportPatternMember::Glob { .. } => overlay.env_vars(),
                     ImportPatternMember::Name { name, span } => {
                         let mut output = vec![];
 

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -866,9 +866,7 @@ pub fn parse_hide(
             }
         } else {
             match &import_pattern.members[0] {
-                ImportPatternMember::Glob { .. } => {
-                    overlay.decls_with_head(&import_pattern.head.name)
-                }
+                ImportPatternMember::Glob { .. } => overlay.decls(),
                 ImportPatternMember::Name { name, span } => {
                     let mut output = vec![];
 

--- a/docs/Modules_and_Overlays.md
+++ b/docs/Modules_and_Overlays.md
@@ -306,7 +306,6 @@ It creates the `$config` variable using the module system.
 
 ## Known Issues
 
-* Hiding from a module needs to be improved: https://github.com/nushell/engine-q/issues/445
 * It might be more appropriate to use `$scope.modules` instead of `$scope.overlays`
 
 ## Future Design Ideas

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -650,7 +650,7 @@ fn hides_def_import_1() -> TestResult {
 #[test]
 fn hides_def_import_2() -> TestResult {
     fail_test(
-        r#"module spam { export def foo [] { "foo" } }; use spam; hide spam *; spam foo"#,
+        r#"module spam { export def foo [] { "foo" } }; use spam; hide spam; spam foo"#,
         not_found_msg(),
     )
 }
@@ -682,7 +682,7 @@ fn hides_def_import_5() -> TestResult {
 #[test]
 fn hides_def_import_6() -> TestResult {
     fail_test(
-        r#"module spam { export def foo [] { "foo" } }; use spam; hide spam; spam foo"#,
+        r#"module spam { export def foo [] { "foo" } }; use spam *; hide spam *; foo"#,
         not_found_msg(),
     )
 }
@@ -698,7 +698,7 @@ fn hides_env_import_1() -> TestResult {
 #[test]
 fn hides_env_import_2() -> TestResult {
     fail_test(
-        r#"module spam { export env foo { "foo" } }; use spam; hide spam *; $nu.env.'spam foo'"#,
+        r#"module spam { export env foo { "foo" } }; use spam; hide spam; $nu.env.'spam foo'"#,
         "did you mean",
     )
 }
@@ -730,7 +730,7 @@ fn hides_env_import_5() -> TestResult {
 #[test]
 fn hides_env_import_6() -> TestResult {
     fail_test(
-        r#"module spam { export env foo { "foo" } }; use spam; hide spam; $nu.env.'spam foo'"#,
+        r#"module spam { export env foo { "foo" } }; use spam *; hide spam *; $nu.env.foo"#,
         "did you mean",
     )
 }


### PR DESCRIPTION
Previously, `hide spam *` would hide `spam foo`, `spam bar`, etc. which is identical to `hide spam`.

Now, `hide spam *` will hide `foo`, `bar`, etc. brought in from `spam` with, e.g., `use spam *`. This was impossible with the previous design.

Fixes #445 