### PR TITLE
Treating environment variables as Values

### DIFF
--- a/crates/nu-cli/src/prompt.rs
+++ b/crates/nu-cli/src/prompt.rs
@@ -8,7 +8,6 @@ use {
 /// Nushell prompt definition
 #[derive(Clone)]
 pub struct NushellPrompt {
-    prompt_command: String,
     prompt_string: String,
     // These are part of the struct definition in case we want to allow
     // further customization to the shell status
@@ -27,7 +26,6 @@ impl Default for NushellPrompt {
 impl NushellPrompt {
     pub fn new() -> NushellPrompt {
         NushellPrompt {
-            prompt_command: "".to_string(),
             prompt_string: "".to_string(),
             default_prompt_indicator: "〉".to_string(),
             default_vi_insert_prompt_indicator: ": ".to_string(),
@@ -36,12 +34,7 @@ impl NushellPrompt {
         }
     }
 
-    pub fn is_new_prompt(&self, prompt_command: &str) -> bool {
-        self.prompt_command != prompt_command
-    }
-
-    pub fn update_prompt(&mut self, prompt_command: String, prompt_string: String) {
-        self.prompt_command = prompt_command;
+    pub fn update_prompt(&mut self, prompt_string: String) {
         self.prompt_string = prompt_string;
     }
 

--- a/crates/nu-command/src/core_commands/use_.rs
+++ b/crates/nu-command/src/core_commands/use_.rs
@@ -88,15 +88,8 @@ impl Command for Use {
 
                 // TODO: Add string conversions (e.g. int to string)
                 // TODO: Later expand env to take all Values
-                let val = if let Ok(s) =
-                    eval_block(engine_state, stack, block, PipelineData::new(call.head))?
-                        .into_value(Span::unknown())
-                        .as_string()
-                {
-                    s
-                } else {
-                    return Err(ShellError::EnvVarNotAString(import_pattern.span()));
-                };
+                let val = eval_block(engine_state, stack, block, PipelineData::new(call.head))?
+                    .into_value(Span::unknown());
 
                 stack.add_env_var(name, val);
             }

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -223,6 +223,7 @@ pub fn create_default_context() -> EngineState {
         bind_command! {
             LetEnv,
             WithEnv,
+            Env,
         };
 
         // Math

--- a/crates/nu-command/src/env/env_command.rs
+++ b/crates/nu-command/src/env/env_command.rs
@@ -29,16 +29,23 @@ impl Command for Env {
         let span = call.head;
         let config = stack.get_config().unwrap_or_default();
 
+        let mut env_vars: Vec<(String, Value)> = stack.get_env_vars().into_iter().collect();
+        env_vars.sort_by(|(name1, _), (name2, _)| name1.cmp(name2));
+
         let mut values = vec![];
 
-        for (name, val) in stack.get_env_vars().into_iter() {
+        for (name, val) in env_vars {
             let mut cols = vec![];
             let mut vals = vec![];
 
             let raw = env_to_string(&name, val.clone(), engine_state, stack, &config)?;
+            let val_type = val.get_type();
 
             cols.push("name".into());
             vals.push(Value::string(name, span));
+
+            cols.push("type".into());
+            vals.push(Value::string(format!("{}", val_type), span));
 
             cols.push("value".into());
             vals.push(val);

--- a/crates/nu-command/src/env/env_command.rs
+++ b/crates/nu-command/src/env/env_command.rs
@@ -1,0 +1,54 @@
+use nu_engine::env_to_string;
+use nu_protocol::ast::Call;
+use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::{Category, IntoPipelineData, PipelineData, Signature, Value};
+
+#[derive(Clone)]
+pub struct Env;
+
+impl Command for Env {
+    fn name(&self) -> &str {
+        "env"
+    }
+
+    fn usage(&self) -> &str {
+        "Display current environment"
+    }
+
+    fn signature(&self) -> nu_protocol::Signature {
+        Signature::build("env").category(Category::Env)
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        let span = call.head;
+        let config = stack.get_config().unwrap_or_default();
+
+        let mut values = vec![];
+
+        for (name, val) in stack.get_env_vars().into_iter() {
+            let mut cols = vec![];
+            let mut vals = vec![];
+
+            let raw = env_to_string(&name, val.clone(), engine_state, stack, &config)?;
+
+            cols.push("name".into());
+            vals.push(Value::string(name, span));
+
+            cols.push("value".into());
+            vals.push(val);
+
+            cols.push("raw".into());
+            vals.push(Value::string(raw, span));
+
+            values.push(Value::Record { cols, vals, span });
+        }
+
+        Ok(Value::List { vals: values, span }.into_pipeline_data())
+    }
+}

--- a/crates/nu-command/src/env/let_env.rs
+++ b/crates/nu-command/src/env/let_env.rs
@@ -20,7 +20,7 @@ impl Command for LetEnv {
             .required("var_name", SyntaxShape::String, "variable name")
             .required(
                 "initial_value",
-                SyntaxShape::Keyword(b"=".to_vec(), Box::new(SyntaxShape::String)),
+                SyntaxShape::Keyword(b"=".to_vec(), Box::new(SyntaxShape::Any)),
                 "equals sign followed by value",
             )
             .category(Category::Env)
@@ -42,9 +42,6 @@ impl Command for LetEnv {
             .expect("internal error: missing keyword");
 
         let rhs = eval_expression(engine_state, stack, keyword_expr)?;
-        let rhs = rhs.as_string()?;
-
-        //println!("Adding: {:?} to {}", rhs, var_id);
 
         stack.add_env_var(env_var, rhs);
         Ok(PipelineData::new(call.head))

--- a/crates/nu-command/src/env/mod.rs
+++ b/crates/nu-command/src/env/mod.rs
@@ -1,5 +1,7 @@
+mod env_command;
 mod let_env;
 mod with_env;
 
+pub use env_command::Env;
 pub use let_env::LetEnv;
 pub use with_env::WithEnv;

--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -1,7 +1,7 @@
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, PipelineData, Signature, SyntaxShape};
+use nu_protocol::{Category, PipelineData, Signature, Span, SyntaxShape, Value};
 
 #[derive(Clone)]
 pub struct Cd;
@@ -44,7 +44,13 @@ impl Command for Cd {
 
         //FIXME: this only changes the current scope, but instead this environment variable
         //should probably be a block that loads the information from the state in the overlay
-        stack.add_env_var("PWD".into(), path);
+        stack.add_env_var(
+            "PWD".into(),
+            Value::String {
+                val: path,
+                span: Span::unknown(),
+            },
+        );
         Ok(PipelineData::new(call.head))
     }
 }

--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -1,7 +1,7 @@
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, PipelineData, Signature, Span, SyntaxShape, Value};
+use nu_protocol::{Category, PipelineData, Signature, SyntaxShape, Value};
 
 #[derive(Clone)]
 pub struct Cd;
@@ -28,29 +28,23 @@ impl Command for Cd {
         call: &Call,
         _input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
-        let path: Option<String> = call.opt(engine_state, stack, 0)?;
+        let path_val: Option<Value> = call.opt(engine_state, stack, 0)?;
 
-        let path = match path {
-            Some(path) => {
-                let path = nu_path::expand_path(path);
-                path.to_string_lossy().to_string()
+        let (path, span) = match path_val {
+            Some(v) => {
+                let path = nu_path::expand_path(v.as_string()?);
+                (path.to_string_lossy().to_string(), v.span()?)
             }
             None => {
                 let path = nu_path::expand_tilde("~");
-                path.to_string_lossy().to_string()
+                (path.to_string_lossy().to_string(), call.head)
             }
         };
         let _ = std::env::set_current_dir(&path);
 
         //FIXME: this only changes the current scope, but instead this environment variable
         //should probably be a block that loads the information from the state in the overlay
-        stack.add_env_var(
-            "PWD".into(),
-            Value::String {
-                val: path,
-                span: Span::unknown(),
-            },
-        );
+        stack.add_env_var("PWD".into(), Value::String { val: path, span });
         Ok(PipelineData::new(call.head))
     }
 }

--- a/crates/nu-command/src/viewers/griddle.rs
+++ b/crates/nu-command/src/viewers/griddle.rs
@@ -141,11 +141,11 @@ fn create_grid_output(
     width_param: Option<String>,
     color_param: bool,
     separator_param: Option<String>,
-    env_str: Option<String>,
+    env_str: Option<Value>,
     use_grid_icons: bool,
 ) -> Result<PipelineData, ShellError> {
     let ls_colors = match env_str {
-        Some(s) => LsColors::from_string(&s),
+        Some(v) => LsColors::from_string(&v.as_string()?),
         None => LsColors::default(),
     };
 

--- a/crates/nu-command/src/viewers/griddle.rs
+++ b/crates/nu-command/src/viewers/griddle.rs
@@ -1,6 +1,7 @@
 // use super::icons::{icon_for_file, iconify_style_ansi_to_nu};
 use super::icons::icon_for_file;
 use lscolors::{LsColors, Style};
+use nu_engine::env_to_string;
 use nu_engine::CallExt;
 use nu_protocol::{
     ast::{Call, PathMember},
@@ -61,7 +62,10 @@ prints out the list properly."#
         let color_param: bool = call.has_flag("color");
         let separator_param: Option<String> = call.get_flag(engine_state, stack, "separator")?;
         let config = stack.get_config().unwrap_or_default();
-        let env_str = stack.get_env_var("LS_COLORS");
+        let env_str = match stack.get_env_var("LS_COLORS") {
+            Some(v) => Some(env_to_string("LS_COLORS", v, engine_state, stack, &config)?),
+            None => None,
+        };
         let use_grid_icons = config.use_grid_icons;
 
         match input {
@@ -141,11 +145,11 @@ fn create_grid_output(
     width_param: Option<String>,
     color_param: bool,
     separator_param: Option<String>,
-    env_str: Option<Value>,
+    env_str: Option<String>,
     use_grid_icons: bool,
 ) -> Result<PipelineData, ShellError> {
     let ls_colors = match env_str {
-        Some(v) => LsColors::from_string(&v.as_string()?),
+        Some(s) => LsColors::from_string(&s),
         None => LsColors::default(),
     };
 

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -74,7 +74,7 @@ impl Command for Table {
                         let ctrlc = ctrlc.clone();
 
                         let ls_colors = match stack.get_env_var("LS_COLORS") {
-                            Some(s) => LsColors::from_string(&s),
+                            Some(v) => LsColors::from_string(&v.as_string()?),
                             None => LsColors::default(),
                         };
 

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -1,5 +1,6 @@
 use lscolors::{LsColors, Style};
 use nu_color_config::{get_color_config, style_primitive};
+use nu_engine::env_to_string;
 use nu_protocol::ast::{Call, PathMember};
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
@@ -74,7 +75,13 @@ impl Command for Table {
                         let ctrlc = ctrlc.clone();
 
                         let ls_colors = match stack.get_env_var("LS_COLORS") {
-                            Some(v) => LsColors::from_string(&v.as_string()?),
+                            Some(v) => LsColors::from_string(&env_to_string(
+                                "LS_COLORS",
+                                v,
+                                engine_state,
+                                stack,
+                                &config,
+                            )?),
                             None => LsColors::default(),
                         };
 

--- a/crates/nu-engine/src/env.rs
+++ b/crates/nu-engine/src/env.rs
@@ -1,0 +1,102 @@
+use std::collections::HashMap;
+
+use nu_protocol::engine::{EngineState, Stack};
+use nu_protocol::{Config, PipelineData, ShellError, Span};
+
+use crate::eval_block;
+
+/// Translate environment variables from Strings to Values. Requires config to be already set up in
+/// case the user defined custom env conversions in config.nu.
+pub fn env_to_values(
+    engine_state: &EngineState,
+    stack: &mut Stack,
+    config: &Config,
+) -> Option<ShellError> {
+    let mut new_env_vars = vec![];
+    let mut error = None;
+
+    for scope in &stack.env_vars {
+        let mut new_scope = HashMap::new();
+
+        for (name, val) in scope {
+            if let Some(conv) = config.env_conversions.get(name) {
+                let block = engine_state.get_block(conv.from_string.0);
+
+                if let Some(var) = block.signature.get_positional(0) {
+                    let mut stack = stack.collect_captures(&block.captures);
+                    if let Some(var_id) = &var.var_id {
+                        stack.add_var(*var_id, val.clone());
+                    }
+
+                    let result = eval_block(
+                        engine_state,
+                        &mut stack,
+                        block,
+                        PipelineData::new(Span::unknown()),
+                    );
+
+                    match result {
+                        Ok(data) => {
+                            let val = data.into_value(Span::unknown());
+                            new_scope.insert(name.to_string(), val);
+                        }
+                        Err(e) => error = error.or(Some(e)),
+                    }
+                } else {
+                    error = error.or_else(|| Some(ShellError::MissingParameter(
+                        "block input".into(),
+                        conv.from_string.1,
+                    )));
+                }
+            } else {
+                new_scope.insert(name.to_string(), val.clone());
+            }
+        }
+
+        new_env_vars.push(new_scope);
+    }
+
+    stack.env_vars = new_env_vars;
+
+    error
+}
+
+/// Translate environment variables from Values to Strings
+pub fn env_to_strings(
+    engine_state: &EngineState,
+    stack: &mut Stack,
+    config: &Config,
+) -> Result<HashMap<String, String>, ShellError> {
+    let env_vars = stack.get_env_vars();
+    let mut env_vars_str = HashMap::new();
+    for (env_name, val) in env_vars {
+        if let Some(conv) = config.env_conversions.get(&env_name) {
+            let block = engine_state.get_block(conv.to_string.0);
+
+            if let Some(var) = block.signature.get_positional(0) {
+                let mut stack = stack.collect_captures(&block.captures);
+                if let Some(var_id) = &var.var_id {
+                    stack.add_var(*var_id, val);
+                }
+
+                let val_str = eval_block(
+                    engine_state,
+                    &mut stack,
+                    block,
+                    PipelineData::new(Span::unknown()),
+                )?
+                .into_value(Span::unknown())
+                .as_string()?;
+
+                env_vars_str.insert(env_name, val_str);
+            } else {
+                return Err(ShellError::MissingParameter(
+                    "block input".into(),
+                    conv.to_string.1,
+                ));
+            }
+        }
+    }
+
+    Ok(env_vars_str)
+}

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -846,7 +846,7 @@ pub fn eval_variable(
     }
 }
 
-pub fn compute(size: i64, unit: Unit, span: Span) -> Value {
+fn compute(size: i64, unit: Unit, span: Span) -> Value {
     match unit {
         Unit::Byte => Value::Filesize { val: size, span },
         Unit::Kilobyte => Value::Filesize {

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -472,13 +472,7 @@ pub fn eval_variable(
 
         let env_vars = stack.get_env_vars();
         let env_columns: Vec<_> = env_vars.keys().map(|x| x.to_string()).collect();
-        let env_values: Vec<_> = env_vars
-            .values()
-            .map(|x| Value::String {
-                val: x.to_string(),
-                span,
-            })
-            .collect();
+        let env_values: Vec<_> = env_vars.values().cloned().collect();
 
         output_cols.push("env".into());
         output_vals.push(Value::Record {

--- a/crates/nu-engine/src/lib.rs
+++ b/crates/nu-engine/src/lib.rs
@@ -1,7 +1,9 @@
 mod call_ext;
 mod documentation;
+mod env;
 mod eval;
 
 pub use call_ext::CallExt;
 pub use documentation::{generate_docs, get_brief_help, get_documentation, get_full_help};
+pub use env::{env_to_strings, env_to_values};
 pub use eval::{eval_block, eval_expression, eval_operator};

--- a/crates/nu-engine/src/lib.rs
+++ b/crates/nu-engine/src/lib.rs
@@ -5,5 +5,5 @@ mod eval;
 
 pub use call_ext::CallExt;
 pub use documentation::{generate_docs, get_brief_help, get_documentation, get_full_help};
-pub use env::{env_to_strings, env_to_values};
+pub use env::*;
 pub use eval::{eval_block, eval_expression, eval_operator};

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -73,7 +73,7 @@ impl Default for Config {
             float_precision: 4,
             filesize_format: "auto".into(),
             use_ansi_coloring: true,
-            env_conversions: HashMap::new(),
+            env_conversions: HashMap::new(), // TODO: Add default conversoins
         }
     }
 }

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -1,8 +1,49 @@
-use crate::{ShellError, Value};
+use crate::{BlockId, ShellError, Span, Value};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 const ANIMATE_PROMPT_DEFAULT: bool = false;
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct EnvConversion {
+    pub from_string: (BlockId, Span),
+    pub to_string: (BlockId, Span),
+}
+
+impl EnvConversion {
+    pub fn from(value: &Value) -> Result<Self, ShellError> {
+        let record = value.as_record()?;
+
+        let mut conv_map = HashMap::new();
+
+        for (k, v) in record.0.iter().zip(record.1) {
+            if (k == "from_string") || (k == "to_string") {
+                conv_map.insert(k.as_str(), (v.as_block()?, v.span()?));
+            } else {
+                return Err(ShellError::UnsupportedConfigValue(
+                    "'from_string' and 'to_string' fields".into(),
+                    k.into(),
+                    value.span()?,
+                ));
+            }
+        }
+
+        match (conv_map.get("from_string"), conv_map.get("to_string")) {
+            (None, _) => Err(ShellError::MissingConfigValue(
+                "'from_string' field".into(),
+                value.span()?,
+            )),
+            (_, None) => Err(ShellError::MissingConfigValue(
+                "'to_string' field".into(),
+                value.span()?,
+            )),
+            (Some(from), Some(to)) => Ok(EnvConversion {
+                from_string: *from,
+                to_string: *to,
+            }),
+        }
+    }
+}
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Config {
@@ -16,6 +57,7 @@ pub struct Config {
     pub float_precision: i64,
     pub filesize_format: String,
     pub use_ansi_coloring: bool,
+    pub env_conversions: HashMap<String, EnvConversion>,
 }
 
 impl Default for Config {
@@ -31,6 +73,7 @@ impl Default for Config {
             float_precision: 4,
             filesize_format: "auto".into(),
             use_ansi_coloring: true,
+            env_conversions: HashMap::new(),
         }
     }
 }
@@ -128,6 +171,16 @@ impl Value {
                 }
                 "filesize_format" => {
                     config.filesize_format = value.as_string()?.to_lowercase();
+                }
+                "env_conversions" => {
+                    let (env_vars, conversions) = value.as_record()?;
+                    let mut env_conversions = HashMap::new();
+
+                    for (env_var, record) in env_vars.iter().zip(conversions) {
+                        env_conversions.insert(env_var.into(), EnvConversion::from(record)?);
+                    }
+
+                    config.env_conversions = env_conversions;
                 }
                 _ => {}
             }

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -11,7 +11,7 @@ pub struct EnvConversion {
 }
 
 impl EnvConversion {
-    pub fn from(value: &Value) -> Result<Self, ShellError> {
+    pub fn from_record(value: &Value) -> Result<Self, ShellError> {
         let record = value.as_record()?;
 
         let mut conv_map = HashMap::new();
@@ -177,7 +177,7 @@ impl Value {
                     let mut env_conversions = HashMap::new();
 
                     for (env_var, record) in env_vars.iter().zip(conversions) {
-                        env_conversions.insert(env_var.into(), EnvConversion::from(record)?);
+                        env_conversions.insert(env_var.into(), EnvConversion::from_record(record)?);
                     }
 
                     config.env_conversions = env_conversions;

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -489,8 +489,7 @@ impl EngineState {
         "<unknown>".into()
     }
 
-    #[allow(unused)]
-    pub(crate) fn add_file(&mut self, filename: String, contents: Vec<u8>) -> usize {
+    pub fn add_file(&mut self, filename: String, contents: Vec<u8>) -> usize {
         let next_span_start = self.next_span_start();
         let next_span_end = next_span_start + contents.len();
 

--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -24,7 +24,7 @@ pub struct Stack {
     /// Variables
     pub vars: HashMap<VarId, Value>,
     /// Environment variables arranged as a stack to be able to recover values from parent scopes
-    pub env_vars: Vec<HashMap<String, String>>,
+    pub env_vars: Vec<HashMap<String, Value>>,
 }
 
 impl Default for Stack {
@@ -53,7 +53,7 @@ impl Stack {
         self.vars.insert(var_id, value);
     }
 
-    pub fn add_env_var(&mut self, var: String, value: String) {
+    pub fn add_env_var(&mut self, var: String, value: Value) {
         if let Some(scope) = self.env_vars.last_mut() {
             scope.insert(var, value);
         } else {
@@ -85,7 +85,7 @@ impl Stack {
     }
 
     /// Flatten the env var scope frames into one frame
-    pub fn get_env_vars(&self) -> HashMap<String, String> {
+    pub fn get_env_vars(&self) -> HashMap<String, Value> {
         let mut result = HashMap::new();
 
         for scope in &self.env_vars {
@@ -95,17 +95,17 @@ impl Stack {
         result
     }
 
-    pub fn get_env_var(&self, name: &str) -> Option<String> {
+    pub fn get_env_var(&self, name: &str) -> Option<Value> {
         for scope in self.env_vars.iter().rev() {
             if let Some(v) = scope.get(name) {
-                return Some(v.to_string());
+                return Some(v.clone());
             }
         }
 
         None
     }
 
-    pub fn remove_env_var(&mut self, name: &str) -> Option<String> {
+    pub fn remove_env_var(&mut self, name: &str) -> Option<Value> {
         for scope in self.env_vars.iter_mut().rev() {
             if let Some(v) = scope.remove(name) {
                 return Some(v);
@@ -135,7 +135,7 @@ impl Stack {
         for (i, scope) in self.env_vars.iter().rev().enumerate() {
             println!("env vars, scope {} (from the last);", i);
             for (var, val) in scope {
-                println!("  {}: {:?}", var, val);
+                println!("  {}: {:?}", var, val.clone().debug_value());
             }
         }
     }

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -235,9 +235,11 @@ pub enum ShellError {
     DowncastNotPossible(String, #[label("{0}")] Span),
 
     #[error("Unsupported config value")]
+    #[diagnostic(code(nu::shell::unsupported_config_value), url(docsrs))]
     UnsupportedConfigValue(String, String, #[label = "expected {0}, got {1}"] Span),
 
     #[error("Missing config value")]
+    #[diagnostic(code(nu::shell::missing_config_value), url(docsrs))]
     MissingConfigValue(String, #[label = "missing {0}"] Span),
 
     #[error("{0}")]

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -99,10 +99,9 @@ pub enum ShellError {
     #[diagnostic(code(nu::shell::variable_not_found), url(docsrs))]
     EnvVarNotFoundAtRuntime(#[label = "environment variable not found"] Span),
 
-    #[error("Environment variable is not a string")]
-    #[diagnostic(code(nu::shell::variable_not_found), url(docsrs))]
-    EnvVarNotAString(#[label = "does not evaluate to a string"] Span),
-
+    // #[error("Environment variable is not a string")]
+    // #[diagnostic(code(nu::shell::variable_not_found), url(docsrs))]
+    // EnvVarNotAString(#[label = "does not evaluate to a string"] Span),
     #[error("Not found.")]
     #[diagnostic(code(nu::parser::not_found), url(docsrs))]
     NotFound(#[label = "did not find anything under this name"] Span),
@@ -234,6 +233,12 @@ pub enum ShellError {
     #[error("Casting error")]
     #[diagnostic(code(nu::shell::downcast_not_possible), url(docsrs))]
     DowncastNotPossible(String, #[label("{0}")] Span),
+
+    #[error("Unsupported config value")]
+    UnsupportedConfigValue(String, String, #[label = "expected {0}, got {1}"] Span),
+
+    #[error("Missing config value")]
+    MissingConfigValue(String, #[label = "missing {0}"] Span),
 
     #[error("{0}")]
     #[diagnostic()]

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,48 +158,8 @@ fn main() -> Result<()> {
             }
         };
 
-        // Translate environment variables from Strings to Values (requires config to get any
-        // custom conversions)
-        let mut new_env_vars = vec![];
-
-        for scope in &stack.env_vars {
-            let mut new_scope = HashMap::new();
-
-            for (name, val) in scope {
-                if let Some(conv) = config.env_conversions.get(name) {
-                    let block = engine_state.get_block(conv.from_string.0);
-
-                    if let Some(var) = block.signature.get_positional(0) {
-                        let mut stack = stack.collect_captures(&block.captures);
-                        if let Some(var_id) = &var.var_id {
-                            stack.add_var(*var_id, val.clone());
-                        }
-
-                        let val = eval_block(
-                            &engine_state,
-                            &mut stack,
-                            block,
-                            PipelineData::new(Span::unknown()),
-                        )?
-                        .into_value(Span::unknown());
-
-                        new_scope.insert(name.to_string(), val);
-                    } else {
-                        let working_set = StateWorkingSet::new(&engine_state);
-                        report_error(
-                            &working_set,
-                            &ShellError::MissingParameter("block input".into(), conv.from_string.1),
-                        )
-                    }
-                } else {
-                    new_scope.insert(name.to_string(), val.clone());
-                }
-            }
-
-            new_env_vars.push(new_scope);
-        }
-
-        stack.env_vars = new_env_vars;
+        // Translate environment variables from Strings to Values
+        convert_env_vars(&engine_state, &mut stack, &config)?;
 
         match eval_block(
             &engine_state,
@@ -338,49 +298,8 @@ fn main() -> Result<()> {
             }
         };
 
-        // Translate environment variables from Strings to Values (requires config to get any
-        // custom conversions)
-        // TODO: deduplicate
-        let mut new_env_vars = vec![];
-
-        for scope in &stack.env_vars {
-            let mut new_scope = HashMap::new();
-
-            for (name, val) in scope {
-                if let Some(conv) = config.env_conversions.get(name) {
-                    let block = engine_state.get_block(conv.from_string.0);
-
-                    if let Some(var) = block.signature.get_positional(0) {
-                        let mut stack = stack.collect_captures(&block.captures);
-                        if let Some(var_id) = &var.var_id {
-                            stack.add_var(*var_id, val.clone());
-                        }
-
-                        let new_val = eval_block(
-                            &engine_state,
-                            &mut stack,
-                            block,
-                            PipelineData::new(Span::unknown()),
-                        )?
-                        .into_value(Span::unknown());
-
-                        new_scope.insert(name.to_string(), new_val);
-                    } else {
-                        let working_set = StateWorkingSet::new(&engine_state);
-                        report_error(
-                            &working_set,
-                            &ShellError::MissingParameter("block input".into(), conv.from_string.1),
-                        )
-                    }
-                } else {
-                    new_scope.insert(name.to_string(), val.clone());
-                }
-            }
-
-            new_env_vars.push(new_scope);
-        }
-
-        stack.env_vars = new_env_vars;
+        // Translate environment variables from Strings to Values
+        convert_env_vars(&engine_state, &mut stack, &config)?;
 
         let history_path = if let Some(mut history_path) = nu_path::config_dir() {
             history_path.push("nushell");
@@ -496,6 +415,57 @@ fn main() -> Result<()> {
 
         Ok(())
     }
+}
+
+// Translate environment variables from Strings to Values. Requires config to be already set up in
+// case the user defined custom env conversions in the config.nu.
+fn convert_env_vars(
+    engine_state: &EngineState,
+    stack: &mut Stack,
+    config: &Config,
+) -> Result<(), ShellError> {
+    let mut new_env_vars = vec![];
+
+    for scope in &stack.env_vars {
+        let mut new_scope = HashMap::new();
+
+        for (name, val) in scope {
+            if let Some(conv) = config.env_conversions.get(name) {
+                let block = engine_state.get_block(conv.from_string.0);
+
+                if let Some(var) = block.signature.get_positional(0) {
+                    let mut stack = stack.collect_captures(&block.captures);
+                    if let Some(var_id) = &var.var_id {
+                        stack.add_var(*var_id, val.clone());
+                    }
+
+                    let val = eval_block(
+                        engine_state,
+                        &mut stack,
+                        block,
+                        PipelineData::new(Span::unknown()),
+                    )?
+                    .into_value(Span::unknown());
+
+                    new_scope.insert(name.to_string(), val);
+                } else {
+                    let working_set = StateWorkingSet::new(engine_state);
+                    report_error(
+                        &working_set,
+                        &ShellError::MissingParameter("block input".into(), conv.from_string.1),
+                    )
+                }
+            } else {
+                new_scope.insert(name.to_string(), val.clone());
+            }
+        }
+
+        new_env_vars.push(new_scope);
+    }
+
+    stack.env_vars = new_env_vars;
+
+    Ok(())
 }
 
 fn print_pipeline_data(

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1067,11 +1067,6 @@ fn shorthand_env_3() -> TestResult {
 }
 
 #[test]
-fn shorthand_env_4() -> TestResult {
-    fail_test(r#"FOO=BAZ FOO= $nu.env.FOO"#, "did you mean")
-}
-
-#[test]
 fn update_cell_path_1() -> TestResult {
     run_test(
         r#"[[name, size]; [a, 1.1]] | into int size | get size.0"#,


### PR DESCRIPTION
## Environment Variables as Values

This PR changes environment variables to be any Value instead of just a String. For example, PATH can be a list:
![path_list2](https://user-images.githubusercontent.com/25571562/146087413-7135199b-a66f-47f0-905c-d41ab8f27b5e.png)


## Configurable Translations from/to a String

You can define custom translation from String (captured from host environment) to Value and from Value back to String (to be sent to external command). For example, translation config for PATH can look like this:
```
let config = {
    # ... other config ...
    env_conversions: {
            "PATH": {
                from_string: { |s| $s | split row ':' }
                to_string: { |v| $v | str collect ':' }
            }
    }
}
```

## No Removing with Nothing

Also, I removed the Nothing value removing the environment variable. If you set an environment variable to Nothing, it will hold this value. If you want to remove it, use `hide`.

## `env` Command 

For easier inspection and debugging, there is now an `env` command:
![env_command](https://user-images.githubusercontent.com/25571562/146462229-2a1b6e61-e768-445e-8075-013c2c675c0e.png)

## TODO (can be left for another PR)
- [x] Make PROMPT_COMMAND a block instead of a string (enables syntax highlighting when writing it)
    - [x] Fix prompt not updating as well
- [x] Check spans of the env var values  (we could have a fake source file that holds the ones captured from `std::env`)
- [x] Change BlockID to Value::Block in EnvConversions to have the span as well (it's (BlockId, Span) tuple now...)
- [x] Check how error messages look like
- [x] `env` command for convenient env var inspection. Ideas:
    - [x] (added column) `env raw` would print the translated values sent to external programs)
    - [ ] `env path` would print the PATH variable name (PATH on Unix, Path on Windows)
    - [x] (added column) `env list` would just print the env vars same as calling `$nu.env` but also print their types
    - [ ] `env to-string` and `env from-string` could encode/decode the env var, but that is the same as calling `do $config.env_conversions.X.from_string` so maybe not necessary
- [x] Move the translation code somewhere instead of free-floating
- [ ] Add default config for PATH etc.
- [ ] Add docs page about this
- [x] Fix env vars passed to external tools:
    - [x] LS_COLORS 
    - [x] run_external 
- [x] Verify externals get all the env
- [ ] Cache the translated strings alongside Values to avoid repeated eval
- [ ] Investigate shorthand `FOO= $nu.env.FOO` being string and not nothing
- [ ] Add tests
- [ ] Better description and examples for env command
- [ ] Add `Value::into_env_string()` -- same as `into_string()` but more env-friendly (e.g., use the env separator by default and do not put `[...]` around lists.