### PR TITLE
Fix comment issue and shadowing issue

### DIFF
--- a/crates/nu-parser/src/lex.rs
+++ b/crates/nu-parser/src/lex.rs
@@ -276,25 +276,18 @@ pub fn lex(
             let mut start = curr_offset;
 
             while let Some(input) = input.get(curr_offset) {
-                curr_offset += 1;
                 if *input == b'\n' || *input == b'\r' {
                     if !skip_comment {
                         output.push(Token::new(
                             TokenContents::Comment,
-                            Span::new(start, curr_offset - 1),
-                        ));
-
-                        // Adding an end of line token after a comment
-                        // This helps during lite_parser to avoid losing a command
-                        // in a statement
-                        output.push(Token::new(
-                            TokenContents::Eol,
-                            Span::new(curr_offset - 1, curr_offset),
+                            Span::new(start, curr_offset),
                         ));
                     }
                     start = curr_offset;
 
                     break;
+                } else {
+                    curr_offset += 1;
                 }
             }
             if start != curr_offset && !skip_comment {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -388,7 +388,7 @@ fn calculate_end_span(
     }
 }
 
-fn parse_multispan_value(
+pub fn parse_multispan_value(
     working_set: &mut StateWorkingSet,
     spans: &[Span],
     spans_idx: &mut usize,

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -91,7 +91,7 @@ pub enum ShellError {
     #[diagnostic(code(nu::shell::nushell_failed), url(docsrs))]
     NushellFailed(String),
 
-    #[error("Variable not found!!!")]
+    #[error("Variable not found")]
     #[diagnostic(code(nu::shell::variable_not_found), url(docsrs))]
     VariableNotFoundAtRuntime(#[label = "variable not found"] Span),
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1249,3 +1249,20 @@ fn command_drop_column_1() -> TestResult {
 fn chained_operator_typecheck() -> TestResult {
     run_test("1 != 2 && 3 != 4 && 5 != 6", "true")
 }
+
+#[test]
+fn proper_shadow() -> TestResult {
+    run_test("let x = 10; let x = $x + 9; $x", "19")
+}
+
+#[test]
+fn comment_multiline() -> TestResult {
+    run_test(
+        r#"def foo [] {
+        let x = 1 + 2 # comment
+        let y = 3 + 4 # another comment
+        $x + $y
+    }; foo"#,
+        "10",
+    )
+}


### PR DESCRIPTION
Fixes these two cases:
```
let x = 10
let x = $x + 9
$x
```
and
```
    def foo [] {
        let x = 1 + 2 # comment
        let y = 3 + 4 # another comment
        $x + $y
    }
    foo
```