### PR TITLE
added a 'list' option to the ansi command

### DIFF
--- a/crates/nu-command/src/strings/char_.rs
+++ b/crates/nu-command/src/strings/char_.rs
@@ -3,7 +3,7 @@ use indexmap::map::IndexMap;
 use lazy_static::lazy_static;
 use nu_engine::CallExt;
 use nu_protocol::{
-    ast::Call, engine::Command, Example, IntoInterruptiblePipelineData, IntoPipelineData,
+    ast::Call, engine::Command, Category, Example, IntoInterruptiblePipelineData, IntoPipelineData,
     PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
 };
 
@@ -132,6 +132,7 @@ impl Command for Char {
             .rest("rest", SyntaxShape::String, "multiple Unicode bytes")
             .switch("list", "List all supported character names", Some('l'))
             .switch("unicode", "Unicode string i.e. 1f378", Some('u'))
+            .category(Category::Strings)
     }
 
     fn usage(&self) -> &str {


### PR DESCRIPTION
Had to change the name -> code from a match statement to a vector that generates a hashmap, so it can be listed. Since there are a lot of shortcodes, I figured just a hashmap literal would get a little too big. Let me know if you can think of a more elegant solution - I am sure there is one.

I also wasn't sure how I should actually display the code - I just removed the escape character, but could print it as text if you prefer. 

Also added a category to the char command - I missed it in my last commit, figured I would sneak it in.