### PR TITLE
Make dialoguer completion abortable

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,7 @@ impl CompletionActionHandler for FuzzyCompletion {
                 .default(0)
                 .items(&selections[..])
                 .interact_on_opt(&Term::stdout())
-                .expect("Fuzzy completion interact on operation");
+                .unwrap_or(None);
             let _ = crossterm::terminal::enable_raw_mode();
 
             if let Some(result) = result {


### PR DESCRIPTION
Fixes #505

Q: Are there any other error cases for dialoguer we have to handle separately?
A: Dialoguer returns a `std::io::Error`, thus if we cannot handle stdout anymore the reedline part would fail loudly as well