### PR TITLE
Fix `Ctrl-D` exit in cli

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -362,9 +362,11 @@ fn main() -> Result<()> {
                     );
                 }
                 Ok(Signal::CtrlC) => {
-                    println!("Ctrl-c");
+                    // `Reedline` clears the line content. New prompt is shown
                 }
                 Ok(Signal::CtrlD) => {
+                    // When exiting clear to a new line
+                    println!();
                     break;
                 }
                 Ok(Signal::CtrlL) => {


### PR DESCRIPTION
Clears to a new line for the potentially hosting process
Remove the output for `Ctrl-C`
