### PR TITLE
python plugin fix stderr write line of code

### DIFF
--- a/crates/nu_plugin_python/plugin.py
+++ b/crates/nu_plugin_python/plugin.py
@@ -114,7 +114,7 @@ def process_call(plugin_call):
     Use this information to implement your plugin logic
     """
     # Pretty printing the call to stderr
-    sys.stderr.write(f"{json.dumps(plugin_call, indent=4)}")
+    sys.stderr.write(json.dumps(plugin_call, indent=4))
     sys.stderr.write("\n")
 
     # Creates a Value of type List that will be encoded and sent to nushell


### PR DESCRIPTION
I had to tweak this one line of code to get it to register the python plugin on my mac...

```python
    # Pretty printing the call to stderr
    sys.stderr.write(json.dumps(plugin_call, indent=4))
    sys.stderr.write("\n")
```