### PR TITLE
Allow empty span slice for now

### DIFF
--- a/crates/nu-protocol/src/span.rs
+++ b/crates/nu-protocol/src/span.rs
@@ -48,11 +48,13 @@ impl Span {
     }
 }
 
+/// Used when you have a slice of spans of at least size 1
 pub fn span(spans: &[Span]) -> Span {
     let length = spans.len();
 
     if length == 0 {
-        panic!("Internal error: tried to create a 0-length span")
+        // TODO: do this for now, but we might also want to protect against this case
+        Span { start: 0, end: 0 }
     } else if length == 1 {
         spans[0]
     } else {


### PR DESCRIPTION
This may not be the right long-term fix, but it at least removes a panic that can happen when you're typing and syntax is incomplete