### PR TITLE
Finish adding support for optional params

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1300,3 +1300,11 @@ fn get_table_columns_1() -> TestResult {
 fn get_table_columns_2() -> TestResult {
     run_test("[[name, age, grade]; [paul,21,a]] | columns | nth 1", "age")
 }
+
+#[test]
+fn allow_missing_optional_params() -> TestResult {
+    run_test(
+        "def foo [x?:int] { if $x != $nothing { $x + 10 } else { 5 } }; foo",
+        "5",
+    )
+}


### PR DESCRIPTION
With this, we can finally finish optional param support and check a param for `$nothing` before using it:

```
def foo [x?:int] {
  if $x != $nothing {
    $x + 10
  } else {
    5
  }
}
foo
```