### PR TITLE
allow `str index-of` and `str substring` to work with CJK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1709,6 +1709,7 @@ dependencies = [
  "rand",
  "rayon",
  "regex",
+ "ropey",
  "roxmltree",
  "rust-embed",
  "serde",
@@ -2564,6 +2565,15 @@ name = "result"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "194d8e591e405d1eecf28819740abed6d719d1a2db87fc0bcdedee9a26d55560"
+
+[[package]]
+name = "ropey"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150aff6deb25b20ed110889f070a678bcd1033e46e5e9d6fb1abeab17947f28"
+dependencies = [
+ "smallvec",
+]
 
 [[package]]
 name = "roxmltree"

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -67,6 +67,7 @@ md5 = { package = "md-5", version = "0.10.0" }
 sha2 = "0.10.0"
 base64 = "0.13.0"
 num = { version = "0.4.0", optional = true }
+ropey = "1.3.1"
 
 [dependencies.polars]
 version = "0.18.0"

--- a/crates/nu-command/src/strings/str_/substring.rs
+++ b/crates/nu-command/src/strings/str_/substring.rs
@@ -129,7 +129,7 @@ fn operate(
 fn action(input: &Value, options: &Substring, head: Span) -> Value {
     match input {
         Value::String { val: s, .. } => {
-            let len: isize = s.len() as isize;
+            let len: isize = s.chars().count() as isize;
 
             let start: isize = if options.0 < 0 {
                 options.0 + len


### PR DESCRIPTION
This was implemented to fix a problem in Nushell. Issue https://github.com/nushell/nushell/issues/4215.

This should work now.
```rust
let s = '[Rust 程序设计语言](title-page.md)'
let start = ($s | str index-of '(')
let end = ($s | str index-of ')')
echo ($s | str substring $'($start + 1),($end)')
```