### PR TITLE
Flatten should flatten embedded table

### DIFF
--- a/crates/nu-command/src/filters/flatten.rs
+++ b/crates/nu-command/src/filters/flatten.rs
@@ -84,12 +84,12 @@ enum TableInside<'a> {
     Entries(&'a str, &'a Span, Vec<&'a Value>),
 }
 
-fn is_table(value: &Value) -> bool {
-    match value {
-        Value::List { vals, span: _ } => vals.iter().all(|f| f.as_record().is_ok()),
-        _ => false,
-    }
-}
+// fn is_table(value: &Value) -> bool {
+//     match value {
+//         Value::List { vals, span: _ } => vals.iter().all(|f| f.as_record().is_ok()),
+//         _ => false,
+//     }
+// }
 
 fn flat_value(columns: &[CellPath], item: &Value, _name_tag: Span) -> Vec<Value> {
     let tag = match item.span() {
@@ -233,7 +233,7 @@ fn flat_value(columns: &[CellPath], item: &Value, _name_tag: Span) -> Vec<Value>
                 expanded.push(r);
             }
             expanded
-        } else if !is_table(item) {
+        } else if item.as_list().is_ok() {
             if let Value::List { vals, span: _ } = item {
                 vals.to_vec()
             } else {

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -195,6 +195,17 @@ impl Value {
         }
     }
 
+    pub fn as_list(&self) -> Result<&[Value], ShellError> {
+        match self {
+            Value::List { vals, .. } => Ok(vals),
+            x => Err(ShellError::CantConvert(
+                "list".into(),
+                x.get_type().to_string(),
+                self.span()?,
+            )),
+        }
+    }
+
     pub fn as_bool(&self) -> Result<bool, ShellError> {
         match self {
             Value::Bool { val, .. } => Ok(*val),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1308,3 +1308,11 @@ fn allow_missing_optional_params() -> TestResult {
         "5",
     )
 }
+
+#[test]
+fn flatten_should_flatten_inner_table() -> TestResult {
+    run_test(
+        "[[[name, value]; [abc, 123]]] | flatten | get value.0",
+        "123",
+    )
+}


### PR DESCRIPTION
Fixes #533 by opening `flatten` up to treat all lists the same. `flatten` now treats an inner table as a list of rows so that those rows can be flattened into the outer table/list.