### PR TITLE
Fix capturing environment variables with " or '

### DIFF
--- a/crates/nu-command/src/path/expand.rs
+++ b/crates/nu-command/src/path/expand.rs
@@ -116,7 +116,7 @@ fn expand(path: &Path, span: Span, args: &Arguments) -> Value {
                 "could not be expanded (path might not exist, non-final \
                     component is not a directory, or other cause)"
                     .into(),
-                span
+                span,
             ),
         }
     } else {

--- a/crates/nu-command/src/path/expand.rs
+++ b/crates/nu-command/src/path/expand.rs
@@ -111,11 +111,12 @@ fn expand(path: &Path, span: Span, args: &Arguments) -> Value {
         Value::string(p.to_string_lossy(), span)
     } else if args.strict {
         Value::Error {
-            error: ShellError::LabeledError(
+            error: ShellError::SpannedLabeledError(
                 "Could not expand path".into(),
                 "could not be expanded (path might not exist, non-final \
                     component is not a directory, or other cause)"
                     .into(),
+                span
             ),
         }
     } else {

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -251,7 +251,7 @@ pub enum ShellError {
     SpannedLabeledErrorHelp(String, String, #[label("{1}")] Span, String),
 
     #[error("{0}")]
-    #[diagnostic()]
+    #[diagnostic(help("{1}"))]
     LabeledError(String, String),
 }
 


### PR DESCRIPTION
If host environment variable contains both ' and ", throw an error.

Also fixed a diagnostic of LabeledError.