### PR TITLE
Signature improvements, sorted completions

### DIFF
--- a/crates/nu-cli/src/completions.rs
+++ b/crates/nu-cli/src/completions.rs
@@ -18,10 +18,8 @@ impl NuCompleter {
     pub fn new(engine_state: EngineState) -> Self {
         Self { engine_state }
     }
-}
 
-impl Completer for NuCompleter {
-    fn complete(&self, line: &str, pos: usize) -> Vec<(reedline::Span, String)> {
+    fn completion_helper(&self, line: &str, pos: usize) -> Vec<(reedline::Span, String)> {
         let mut working_set = StateWorkingSet::new(&self.engine_state);
         let offset = working_set.next_span_start();
         let pos = offset + pos;
@@ -198,6 +196,16 @@ impl Completer for NuCompleter {
         }
 
         vec![]
+    }
+}
+
+impl Completer for NuCompleter {
+    fn complete(&self, line: &str, pos: usize) -> Vec<(reedline::Span, String)> {
+        let mut output = self.completion_helper(line, pos);
+
+        output.sort_by(|a, b| a.1.cmp(&b.1));
+
+        output
     }
 }
 

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -614,7 +614,7 @@ pub fn eval_variable(
                             Value::string(&signature.name, span),
                             Value::string(req.name, span),
                             Value::string("positional", span),
-                            Value::string(req.shape.to_type().to_string(), span),
+                            Value::string(req.shape.to_string(), span),
                             Value::boolean(false, span),
                             Value::nothing(span),
                             Value::string(req.desc, span),
@@ -633,7 +633,7 @@ pub fn eval_variable(
                             Value::string(&signature.name, span),
                             Value::string(opt.name, span),
                             Value::string("positional", span),
-                            Value::string(opt.shape.to_type().to_string(), span),
+                            Value::string(opt.shape.to_string(), span),
                             Value::boolean(true, span),
                             Value::nothing(span),
                             Value::string(opt.desc, span),
@@ -648,42 +648,39 @@ pub fn eval_variable(
 
                     {
                         // rest_positional
-                        let (name, shape, desc) = if let Some(rest) = signature.rest_positional {
-                            (
+                        if let Some(rest) = signature.rest_positional {
+                            let sig_vals = vec![
+                                Value::string(&signature.name, span),
                                 Value::string(rest.name, span),
-                                Value::string(rest.shape.to_type().to_string(), span),
+                                Value::string("rest", span),
+                                Value::string(rest.shape.to_string(), span),
+                                Value::boolean(true, span),
+                                Value::nothing(span),
                                 Value::string(rest.desc, span),
-                            )
-                        } else {
-                            (
-                                Value::nothing(span),
-                                Value::nothing(span),
-                                Value::nothing(span),
-                            )
-                        };
+                            ];
 
-                        let sig_vals = vec![
-                            Value::string(&signature.name, span),
-                            name,
-                            Value::string("rest", span),
-                            shape,
-                            Value::boolean(false, span),
-                            Value::nothing(span),
-                            desc,
-                        ];
-
-                        sig_records.push(Value::Record {
-                            cols: sig_cols.clone(),
-                            vals: sig_vals,
-                            span,
-                        });
+                            sig_records.push(Value::Record {
+                                cols: sig_cols.clone(),
+                                vals: sig_vals,
+                                span,
+                            });
+                        }
                     }
 
                     // named flags
                     for named in signature.named {
+                        let flag_type;
+
+                        // Skip the help flag
+                        if named.long == "help" {
+                            continue;
+                        }
+
                         let shape = if let Some(arg) = named.arg {
-                            Value::string(arg.to_type().to_string(), span)
+                            flag_type = Value::string("named", span);
+                            Value::string(arg.to_string(), span)
                         } else {
+                            flag_type = Value::string("switch", span);
                             Value::nothing(span)
                         };
 
@@ -696,7 +693,7 @@ pub fn eval_variable(
                         let sig_vals = vec![
                             Value::string(&signature.name, span),
                             Value::string(named.long, span),
-                            Value::string("named", span),
+                            flag_type,
                             shape,
                             Value::boolean(!named.required, span),
                             short_flag,

--- a/crates/nu-protocol/src/syntax_shape.rs
+++ b/crates/nu-protocol/src/syntax_shape.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use serde::{Deserialize, Serialize};
 
 use crate::Type;
@@ -113,6 +115,40 @@ impl SyntaxShape {
             SyntaxShape::Table => Type::List(Box::new(Type::Unknown)), // FIXME: Tables should have better types
             SyntaxShape::VarWithOptType => Type::Unknown,
             SyntaxShape::Variable => Type::Unknown,
+        }
+    }
+}
+
+impl Display for SyntaxShape {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SyntaxShape::Keyword(kw, shape) => {
+                write!(f, "\"{}\" {}", String::from_utf8_lossy(kw), shape)
+            }
+            SyntaxShape::Any => write!(f, "any"),
+            SyntaxShape::String => write!(f, "string"),
+            SyntaxShape::CellPath => write!(f, "cellpath"),
+            SyntaxShape::FullCellPath => write!(f, "cellpath"),
+            SyntaxShape::Number => write!(f, "number"),
+            SyntaxShape::Range => write!(f, "range"),
+            SyntaxShape::Int => write!(f, "int"),
+            SyntaxShape::Filepath => write!(f, "path"),
+            SyntaxShape::GlobPattern => write!(f, "glob"),
+            SyntaxShape::ImportPattern => write!(f, "import"),
+            SyntaxShape::Block(_) => write!(f, "block"),
+            SyntaxShape::Table => write!(f, "table"),
+            SyntaxShape::List(x) => write!(f, "list<{}>", x),
+            SyntaxShape::Filesize => write!(f, "filesize"),
+            SyntaxShape::Duration => write!(f, "duration"),
+            SyntaxShape::Operator => write!(f, "operator"),
+            SyntaxShape::RowCondition => write!(f, "condition"),
+            SyntaxShape::MathExpression => write!(f, "variable"),
+            SyntaxShape::Variable => write!(f, "var"),
+            SyntaxShape::VarWithOptType => write!(f, "vardecl"),
+            SyntaxShape::Signature => write!(f, "signature"),
+            SyntaxShape::Expression => write!(f, "expression"),
+            SyntaxShape::Boolean => write!(f, "bool"),
+            SyntaxShape::Custom(x, _) => write!(f, "custom<{}>", x),
         }
     }
 }


### PR DESCRIPTION
This does a few improvements to the structured signature:
* skips the `help` flag
* named flags that don't take an arg are now called `switch`
* show the syntax shape instead of the type
* fixed a bug where `rest` was showing up even if the command didn't have one

I also threw in sorting of completions because I was fixing that when I switched tasks :rofl: 