### PR TITLE
Wrap captured env var names into quotes as well

### DIFF
--- a/crates/nu-parser/src/lib.rs
+++ b/crates/nu-parser/src/lib.rs
@@ -15,7 +15,7 @@ pub use lite_parse::{lite_parse, LiteBlock};
 pub use parse_keywords::{
     parse_alias, parse_def, parse_def_predecl, parse_let, parse_module, parse_use,
 };
-pub use parser::{find_captures_in_expr, parse, Import};
+pub use parser::{find_captures_in_expr, parse, trim_quotes, Import};
 
 #[cfg(feature = "plugin")]
 pub use parse_keywords::parse_register;


### PR DESCRIPTION
When starting engine-q, both the name and the value in the fake file will be put between quotes or double quotes to ensure any weird characters don't break break it. Also, error reporting got cleared up a bit and removed a potential panic. 