### PR TITLE
add in a raw flag in the command to json

### DIFF
--- a/crates/nu-command/src/formats/to/json.rs
+++ b/crates/nu-command/src/formats/to/json.rs
@@ -13,7 +13,9 @@ impl Command for ToJson {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("to json").category(Category::Formats)
+        Signature::build("to json")
+            .switch("raw", "remove all of the whitespace", Some('r'))
+            .category(Category::Formats)
     }
 
     fn usage(&self) -> &str {
@@ -27,7 +29,12 @@ impl Command for ToJson {
         call: &Call,
         input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, ShellError> {
-        to_json(call, input)
+        let raw = call.has_flag("raw");
+        if raw {
+            to_json_raw(call, input)
+        } else {
+            to_json(call, input)
+        }
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -94,6 +101,25 @@ fn to_json(call: &Call, input: PipelineData) -> Result<PipelineData, ShellError>
 
     let json_value = value_to_json_value(&value)?;
     match nu_json::to_string(&json_value) {
+        Ok(serde_json_string) => Ok(Value::String {
+            val: serde_json_string,
+            span,
+        }
+        .into_pipeline_data()),
+        _ => Ok(Value::Error {
+            error: ShellError::CantConvert("JSON".into(), value.get_type().to_string(), span),
+        }
+        .into_pipeline_data()),
+    }
+}
+
+fn to_json_raw(call: &Call, input: PipelineData) -> Result<PipelineData, ShellError> {
+    let span = call.head;
+
+    let value = input.into_value(span);
+
+    let json_value = value_to_json_value(&value)?;
+    match nu_json::to_string_raw(&json_value) {
         Ok(serde_json_string) => Ok(Value::String {
             val: serde_json_string,
             span,

--- a/crates/nu-json/src/lib.rs
+++ b/crates/nu-json/src/lib.rs
@@ -2,7 +2,7 @@ pub use self::de::{
     from_iter, from_reader, from_slice, from_str, Deserializer, StreamDeserializer,
 };
 pub use self::error::{Error, ErrorCode, Result};
-pub use self::ser::{to_string, to_vec, to_writer, Serializer};
+pub use self::ser::{to_string, to_string_raw, to_vec, to_writer, Serializer};
 pub use self::value::{from_value, to_value, Map, Value};
 
 pub mod builder;

--- a/crates/nu-json/src/ser.rs
+++ b/crates/nu-json/src/ser.rs
@@ -1023,3 +1023,16 @@ where
     let string = String::from_utf8(vec)?;
     Ok(string)
 }
+
+/// Encode the specified struct into a Hjson `String` buffer.
+/// And remove all whitespace
+#[inline]
+pub fn to_string_raw<T>(value: &T) -> Result<String>
+where
+    T: ser::Serialize,
+{
+    let vec = to_vec(value)?;
+    let mut string = String::from_utf8(vec)?;
+    string.retain(|c| !c.is_whitespace());
+    Ok(string)
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1324,3 +1324,11 @@ fn cjk_in_substrings() -> TestResult {
         "title-page.md",
     )
 }
+
+#[test]
+fn to_json_raw_flag() -> TestResult {
+    run_test(
+        "[[a b]; [jim susie] [3 4]] | to json -r",
+        r#"[{"a":"jim","b":"susie"},{"a":3,"b":4}]"#,
+    )
+}


### PR DESCRIPTION

This gives us the ability to get back the json with out the table formatting
in the string...

```rust
[[a b]; [jim susie] [3 4]] | to json -r
```

will produce just the json unformatted...

```rust
[{"a":"jim","b":"susie"},{"a":3,"b":4}]
```

Prior to this addition @fdncred pointed out to me that this
was an alternative solution, which is kind of nice too, but just
a bit more verbose...

```rust
[[a b]; [jim susie] [3 4]] | to json | str find-replace '\n' '' -a | str trim -a
```