### PR TITLE
add configuration of maximum history size

### DIFF
--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -52,6 +52,7 @@ pub struct Config {
     pub use_ansi_coloring: bool,
     pub env_conversions: HashMap<String, EnvConversion>,
     pub edit_mode: String,
+    pub max_history_size: i64,
 }
 
 impl Default for Config {
@@ -69,6 +70,7 @@ impl Default for Config {
             use_ansi_coloring: true,
             env_conversions: HashMap::new(), // TODO: Add default conversoins
             edit_mode: "emacs".into(),
+            max_history_size: 1000,
         }
     }
 }
@@ -180,6 +182,9 @@ impl Value {
                 }
                 "edit_mode" => {
                     config.edit_mode = value.as_string()?;
+                }
+                "max_history_size" => {
+                    config.max_history_size = value.as_i64()?;
                 }
                 _ => {}
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -364,8 +364,11 @@ fn main() -> Result<()> {
                             ),
                         ))
                         .with_history(Box::new(
-                            FileBackedHistory::with_file(1000, history_path.clone())
-                                .into_diagnostic()?,
+                            FileBackedHistory::with_file(
+                                config.max_history_size as usize,
+                                history_path.clone(),
+                            )
+                            .into_diagnostic()?,
                         ))
                         .into_diagnostic()?
                 } else {


### PR DESCRIPTION
allows one to set the maximum size of their history file with this configuration point. max_history_size defaults to 1000.

```
let config = {
    max_history_size: 10000
}
```