### PR TITLE
add configuration point for hint coloring

### DIFF
--- a/crates/nu-color-config/src/color_config.rs
+++ b/crates/nu-color-config/src/color_config.rs
@@ -4,17 +4,6 @@ use nu_protocol::Config;
 use nu_table::{Alignment, TextStyle};
 use std::collections::HashMap;
 
-//TODO: should this be implemented again?
-// pub fn number(number: impl Into<Number>) -> Primitive {
-//     let number = number.into();
-
-//     match number {
-//         Number::BigInt(int) => Primitive::BigInt(int),
-//         Number::Int(int) => Primitive::Int(int),
-//         Number::Decimal(decimal) => Primitive::Decimal(decimal),
-//     }
-// }
-
 pub fn lookup_ansi_color_style(s: String) -> Style {
     if s.starts_with('#') {
         match color_from_hex(&s) {
@@ -36,6 +25,16 @@ pub fn lookup_ansi_color_style(s: String) -> Style {
             "gr" | "green_reverse" => Color::Green.reverse(),
             "gbl" | "green_blink" => Color::Green.blink(),
             "gst" | "green_strike" => Color::Green.strikethrough(),
+
+            "lg" | "light_green" => Color::LightGreen.normal(),
+            "lgb" | "light_green_bold" => Color::LightGreen.bold(),
+            "lgu" | "light_green_underline" => Color::LightGreen.underline(),
+            "lgi" | "light_green_italic" => Color::LightGreen.italic(),
+            "lgd" | "light_green_dimmed" => Color::LightGreen.dimmed(),
+            "lgr" | "light_green_reverse" => Color::LightGreen.reverse(),
+            "lgbl" | "light_green_blink" => Color::LightGreen.blink(),
+            "lgst" | "light_green_strike" => Color::LightGreen.strikethrough(),
+
             "r" | "red" => Color::Red.normal(),
             "rb" | "red_bold" => Color::Red.bold(),
             "ru" | "red_underline" => Color::Red.underline(),
@@ -44,6 +43,16 @@ pub fn lookup_ansi_color_style(s: String) -> Style {
             "rr" | "red_reverse" => Color::Red.reverse(),
             "rbl" | "red_blink" => Color::Red.blink(),
             "rst" | "red_strike" => Color::Red.strikethrough(),
+
+            "lr" | "light_red" => Color::LightRed.normal(),
+            "lrb" | "light_red_bold" => Color::LightRed.bold(),
+            "lru" | "light_red_underline" => Color::LightRed.underline(),
+            "lri" | "light_red_italic" => Color::LightRed.italic(),
+            "lrd" | "light_red_dimmed" => Color::LightRed.dimmed(),
+            "lrr" | "light_red_reverse" => Color::LightRed.reverse(),
+            "lrbl" | "light_red_blink" => Color::LightRed.blink(),
+            "lrst" | "light_red_strike" => Color::LightRed.strikethrough(),
+
             "u" | "blue" => Color::Blue.normal(),
             "ub" | "blue_bold" => Color::Blue.bold(),
             "uu" | "blue_underline" => Color::Blue.underline(),
@@ -52,6 +61,16 @@ pub fn lookup_ansi_color_style(s: String) -> Style {
             "ur" | "blue_reverse" => Color::Blue.reverse(),
             "ubl" | "blue_blink" => Color::Blue.blink(),
             "ust" | "blue_strike" => Color::Blue.strikethrough(),
+
+            "lu" | "light_blue" => Color::LightBlue.normal(),
+            "lub" | "light_blue_bold" => Color::LightBlue.bold(),
+            "luu" | "light_blue_underline" => Color::LightBlue.underline(),
+            "lui" | "light_blue_italic" => Color::LightBlue.italic(),
+            "lud" | "light_blue_dimmed" => Color::LightBlue.dimmed(),
+            "lur" | "light_blue_reverse" => Color::LightBlue.reverse(),
+            "lubl" | "light_blue_blink" => Color::LightBlue.blink(),
+            "lust" | "light_blue_strike" => Color::LightBlue.strikethrough(),
+
             "b" | "black" => Color::Black.normal(),
             "bb" | "black_bold" => Color::Black.bold(),
             "bu" | "black_underline" => Color::Black.underline(),
@@ -60,6 +79,16 @@ pub fn lookup_ansi_color_style(s: String) -> Style {
             "br" | "black_reverse" => Color::Black.reverse(),
             "bbl" | "black_blink" => Color::Black.blink(),
             "bst" | "black_strike" => Color::Black.strikethrough(),
+
+            "ligr" | "light_gray" => Color::LightGray.normal(),
+            "ligrb" | "light_gray_bold" => Color::LightGray.bold(),
+            "ligru" | "light_gray_underline" => Color::LightGray.underline(),
+            "ligri" | "light_gray_italic" => Color::LightGray.italic(),
+            "ligrd" | "light_gray_dimmed" => Color::LightGray.dimmed(),
+            "ligrr" | "light_gray_reverse" => Color::LightGray.reverse(),
+            "ligrbl" | "light_gray_blink" => Color::LightGray.blink(),
+            "ligrst" | "light_gray_strike" => Color::LightGray.strikethrough(),
+
             "y" | "yellow" => Color::Yellow.normal(),
             "yb" | "yellow_bold" => Color::Yellow.bold(),
             "yu" | "yellow_underline" => Color::Yellow.underline(),
@@ -68,6 +97,16 @@ pub fn lookup_ansi_color_style(s: String) -> Style {
             "yr" | "yellow_reverse" => Color::Yellow.reverse(),
             "ybl" | "yellow_blink" => Color::Yellow.blink(),
             "yst" | "yellow_strike" => Color::Yellow.strikethrough(),
+
+            "ly" | "light_yellow" => Color::LightYellow.normal(),
+            "lyb" | "light_yellow_bold" => Color::LightYellow.bold(),
+            "lyu" | "light_yellow_underline" => Color::LightYellow.underline(),
+            "lyi" | "light_yellow_italic" => Color::LightYellow.italic(),
+            "lyd" | "light_yellow_dimmed" => Color::LightYellow.dimmed(),
+            "lyr" | "light_yellow_reverse" => Color::LightYellow.reverse(),
+            "lybl" | "light_yellow_blink" => Color::LightYellow.blink(),
+            "lyst" | "light_yellow_strike" => Color::LightYellow.strikethrough(),
+
             "p" | "purple" => Color::Purple.normal(),
             "pb" | "purple_bold" => Color::Purple.bold(),
             "pu" | "purple_underline" => Color::Purple.underline(),
@@ -76,6 +115,16 @@ pub fn lookup_ansi_color_style(s: String) -> Style {
             "pr" | "purple_reverse" => Color::Purple.reverse(),
             "pbl" | "purple_blink" => Color::Purple.blink(),
             "pst" | "purple_strike" => Color::Purple.strikethrough(),
+
+            "lp" | "light_purple" => Color::LightPurple.normal(),
+            "lpb" | "light_purple_bold" => Color::LightPurple.bold(),
+            "lpu" | "light_purple_underline" => Color::LightPurple.underline(),
+            "lpi" | "light_purple_italic" => Color::LightPurple.italic(),
+            "lpd" | "light_purple_dimmed" => Color::LightPurple.dimmed(),
+            "lpr" | "light_purple_reverse" => Color::LightPurple.reverse(),
+            "lpbl" | "light_purple_blink" => Color::LightPurple.blink(),
+            "lpst" | "light_purple_strike" => Color::LightPurple.strikethrough(),
+
             "c" | "cyan" => Color::Cyan.normal(),
             "cb" | "cyan_bold" => Color::Cyan.bold(),
             "cu" | "cyan_underline" => Color::Cyan.underline(),
@@ -84,6 +133,16 @@ pub fn lookup_ansi_color_style(s: String) -> Style {
             "cr" | "cyan_reverse" => Color::Cyan.reverse(),
             "cbl" | "cyan_blink" => Color::Cyan.blink(),
             "cst" | "cyan_strike" => Color::Cyan.strikethrough(),
+
+            "lc" | "light_cyan" => Color::LightCyan.normal(),
+            "lcb" | "light_cyan_bold" => Color::LightCyan.bold(),
+            "lcu" | "light_cyan_underline" => Color::LightCyan.underline(),
+            "lci" | "light_cyan_italic" => Color::LightCyan.italic(),
+            "lcd" | "light_cyan_dimmed" => Color::LightCyan.dimmed(),
+            "lcr" | "light_cyan_reverse" => Color::LightCyan.reverse(),
+            "lcbl" | "light_cyan_blink" => Color::LightCyan.blink(),
+            "lcst" | "light_cyan_strike" => Color::LightCyan.strikethrough(),
+
             "w" | "white" => Color::White.normal(),
             "wb" | "white_bold" => Color::White.bold(),
             "wu" | "white_underline" => Color::White.underline(),
@@ -92,36 +151,20 @@ pub fn lookup_ansi_color_style(s: String) -> Style {
             "wr" | "white_reverse" => Color::White.reverse(),
             "wbl" | "white_blink" => Color::White.blink(),
             "wst" | "white_strike" => Color::White.strikethrough(),
+
+            "dgr" | "dark_gray" => Color::DarkGray.normal(),
+            "dgrb" | "dark_gray_bold" => Color::DarkGray.bold(),
+            "dgru" | "dark_gray_underline" => Color::DarkGray.underline(),
+            "dgri" | "dark_gray_italic" => Color::DarkGray.italic(),
+            "dgrd" | "dark_gray_dimmed" => Color::DarkGray.dimmed(),
+            "dgrr" | "dark_gray_reverse" => Color::DarkGray.reverse(),
+            "dgrbl" | "dark_gray_blink" => Color::DarkGray.blink(),
+            "dgrst" | "dark_gray_strike" => Color::DarkGray.strikethrough(),
+
             _ => Color::White.normal(),
         }
     }
 }
-
-// TODO: i'm not sure how this ever worked but leaving it in case it's used elsewhere but not implemented yet
-// pub fn string_to_lookup_value(str_prim: &str) -> String {
-//     match str_prim {
-//         "primitive_int" => "Primitive::Int".to_string(),
-//         "primitive_decimal" => "Primitive::Decimal".to_string(),
-//         "primitive_filesize" => "Primitive::Filesize".to_string(),
-//         "primitive_string" => "Primitive::String".to_string(),
-//         "primitive_line" => "Primitive::Line".to_string(),
-//         "primitive_columnpath" => "Primitive::ColumnPath".to_string(),
-//         "primitive_pattern" => "Primitive::GlobPattern".to_string(),
-//         "primitive_boolean" => "Primitive::Boolean".to_string(),
-//         "primitive_date" => "Primitive::Date".to_string(),
-//         "primitive_duration" => "Primitive::Duration".to_string(),
-//         "primitive_range" => "Primitive::Range".to_string(),
-//         "primitive_path" => "Primitive::FilePath".to_string(),
-//         "primitive_binary" => "Primitive::Binary".to_string(),
-//         "separator_color" => "separator_color".to_string(),
-//         "header_align" => "header_align".to_string(),
-//         "header_color" => "header_color".to_string(),
-//         "header_style" => "header_style".to_string(),
-//         "index_color" => "index_color".to_string(),
-//         "leading_trailing_space_bg" => "leading_trailing_space_bg".to_string(),
-//         _ => "Primitive::Nothing".to_string(),
-//     }
-// }
 
 fn update_hashmap(key: &str, val: &str, hm: &mut HashMap<String, Style>) {
     // eprintln!("key: {}, val: {}", &key, &val);
@@ -139,32 +182,16 @@ pub fn get_color_config(config: &Config) -> HashMap<String, Style> {
     // create the hashmap
     let mut hm: HashMap<String, Style> = HashMap::new();
     // set some defaults
-    // hm.insert("primitive_int".to_string(), Color::White.normal());
-    // hm.insert("primitive_decimal".to_string(), Color::White.normal());
-    // hm.insert("primitive_filesize".to_string(), Color::White.normal());
-    // hm.insert("primitive_string".to_string(), Color::White.normal());
     // hm.insert("primitive_line".to_string(), Color::White.normal());
-    // hm.insert("primitive_columnpath".to_string(), Color::White.normal());
     // hm.insert("primitive_pattern".to_string(), Color::White.normal());
-    // hm.insert("primitive_boolean".to_string(), Color::White.normal());
-    // hm.insert("primitive_date".to_string(), Color::White.normal());
-    // hm.insert("primitive_duration".to_string(), Color::White.normal());
-    // hm.insert("primitive_range".to_string(), Color::White.normal());
     // hm.insert("primitive_path".to_string(), Color::White.normal());
-    // hm.insert("primitive_binary".to_string(), Color::White.normal());
     // hm.insert("separator_color".to_string(), Color::White.normal());
-    // hm.insert("header_align".to_string(), Color::Green.bold());
-    // hm.insert("header_color".to_string(), Color::Green.bold());
-    // hm.insert("header_style".to_string(), Style::default());
-    // hm.insert("index_color".to_string(), Color::Green.bold());
     hm.insert(
         "leading_trailing_space_bg".to_string(),
         Style::default().on(Color::Rgb(128, 128, 128)),
     );
-
     hm.insert("header".to_string(), Color::Green.bold());
     hm.insert("empty".to_string(), Color::Blue.normal());
-
     hm.insert("bool".to_string(), Color::White.normal());
     hm.insert("int".to_string(), Color::White.normal());
     hm.insert("filesize".to_string(), Color::White.normal());
@@ -180,6 +207,7 @@ pub fn get_color_config(config: &Config) -> HashMap<String, Style> {
     hm.insert("record".to_string(), Color::White.normal());
     hm.insert("list".to_string(), Color::White.normal());
     hm.insert("block".to_string(), Color::White.normal());
+    hm.insert("hints".to_string(), Color::DarkGray.normal());
 
     for (key, value) in &config.color_config {
         update_hashmap(key, value, &mut hm);
@@ -340,34 +368,6 @@ pub fn style_primitive(primitive: &str, color_hm: &HashMap<String, Style>) -> Te
         //     match style {
         //         Some(s) => TextStyle::with_style(Alignment::Left, *s),
         //         None => TextStyle::basic_left(),
-        //     }
-        // }
-        // "separator_color" => {
-        //     let style = color_hm.get("separator");
-        //     match style {
-        //         Some(s) => TextStyle::with_style(Alignment::Left, *s),
-        //         None => TextStyle::basic_left(),
-        //     }
-        // }
-        // "header_align" => {
-        //     let style = color_hm.get("header_align");
-        //     match style {
-        //         Some(s) => TextStyle::with_style(Alignment::Center, *s),
-        //         None => TextStyle::default_header(),
-        //     }
-        // }
-        // "header_color" => {
-        //     let style = color_hm.get("header_color");
-        //     match style {
-        //         Some(s) => TextStyle::with_style(Alignment::Center, *s),
-        //         None => TextStyle::default_header().bold(Some(true)),
-        //     }
-        // }
-        // "header_style" => {
-        //     let style = color_hm.get("header_style");
-        //     match style {
-        //         Some(s) => TextStyle::with_style(Alignment::Center, *s),
-        //         None => TextStyle::default_header(),
         //     }
         // }
         _ => TextStyle::basic_left(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use dialoguer::{
 };
 use miette::{IntoDiagnostic, Result};
 use nu_cli::{CliError, NuCompleter, NuHighlighter, NuValidator, NushellPrompt};
+use nu_color_config::get_color_config;
 use nu_command::create_default_context;
 use nu_engine::{convert_env_values, eval_block};
 use nu_parser::{lex, parse, trim_quotes, Token, TokenContents};
@@ -354,14 +355,16 @@ fn main() -> Result<()> {
             //FIXME: if config.use_ansi_coloring is false then we should
             // turn off the hinter but I don't see any way to do that yet.
 
+            let color_hm = get_color_config(&config);
+
             let line_editor = if let Some(history_path) = history_path.clone() {
                 let history = std::fs::read_to_string(&history_path);
                 if history.is_ok() {
                     line_editor
                         .with_hinter(Box::new(
-                            DefaultHinter::default().with_history().with_style(
-                                nu_ansi_term::Style::new().fg(nu_ansi_term::Color::DarkGray),
-                            ),
+                            DefaultHinter::default()
+                                .with_history()
+                                .with_style(color_hm["hints"]),
                         ))
                         .with_history(Box::new(
                             FileBackedHistory::with_file(1000, history_path.clone())


### PR DESCRIPTION
this pr allows one to change the color of hints. by default hints are dark gray.

```
let config = {
  color_config: {
    hints: dark_gray
  }
}
```