### PR TITLE
Flush stmts

### DIFF
--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -1,4 +1,5 @@
 use std::cmp::Ordering;
+use std::io::Write;
 
 use nu_protocol::ast::{Block, Call, Expr, Expression, Operator, Statement};
 use nu_protocol::engine::{EngineState, Stack};
@@ -383,7 +384,9 @@ pub fn eval_block(
     block: &Block,
     mut input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
-    for stmt in block.stmts.iter() {
+    let config = stack.get_config().unwrap_or_default();
+    let num_stmts = block.stmts.len();
+    for (stmt_idx, stmt) in block.stmts.iter().enumerate() {
         if let Statement::Pipeline(pipeline) = stmt {
             for (i, elem) in pipeline.expressions.iter().enumerate() {
                 match elem {
@@ -413,6 +416,56 @@ pub fn eval_block(
                     }
                 }
             }
+        }
+
+        if stmt_idx < (num_stmts) - 1 {
+            // Drain the input to the screen via tabular output
+
+            match engine_state.find_decl("table".as_bytes()) {
+                Some(decl_id) => {
+                    let table = engine_state.get_decl(decl_id).run(
+                        engine_state,
+                        stack,
+                        &Call::new(),
+                        input,
+                    )?;
+
+                    for item in table {
+                        let stdout = std::io::stdout();
+
+                        if let Value::Error { error } = item {
+                            return Err(error);
+                        }
+
+                        let mut out = item.into_string("\n", &config);
+                        out.push('\n');
+
+                        match stdout.lock().write_all(out.as_bytes()) {
+                            Ok(_) => (),
+                            Err(err) => eprintln!("{}", err),
+                        };
+                    }
+                }
+                None => {
+                    for item in input {
+                        let stdout = std::io::stdout();
+
+                        if let Value::Error { error } = item {
+                            return Err(error);
+                        }
+
+                        let mut out = item.into_string("\n", &config);
+                        out.push('\n');
+
+                        match stdout.lock().write_all(out.as_bytes()) {
+                            Ok(_) => (),
+                            Err(err) => eprintln!("{}", err),
+                        };
+                    }
+                }
+            };
+
+            input = PipelineData::new(Span { start: 0, end: 0 })
         }
     }
 

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -3,7 +3,7 @@ use crate::tests::{fail_test, run_test, TestResult};
 #[test]
 fn concrete_variable_assignment() -> TestResult {
     run_test(
-        "let x = (1..100 | each { |y| $y + 100 }); $x | length; $x | length",
+        "let x = (1..100 | each { |y| $y + 100 }); let y = ($x | length); $x | length",
         "100",
     )
 }


### PR DESCRIPTION
Flushes the statements in a block leading up to the last pipeline.

This allows for things like `do { echo 3; echo 4 }` to show both the 3 and 4