### PR TITLE
Use only $nu.env.PWD for getting the current directory

### DIFF
--- a/crates/nu-command/src/core_commands/for_.rs
+++ b/crates/nu-command/src/core_commands/for_.rs
@@ -79,7 +79,7 @@ impl Command for For {
                 .into_iter()
                 .enumerate()
                 .map(move |(idx, x)| {
-                    stack.with_env(orig_env_vars.clone(), orig_env_hidden.clone());
+                    stack.with_env(&orig_env_vars, &orig_env_hidden);
 
                     stack.add_var(
                         var_id,
@@ -111,7 +111,7 @@ impl Command for For {
                 .into_range_iter()?
                 .enumerate()
                 .map(move |(idx, x)| {
-                    stack.with_env(orig_env_vars.clone(), orig_env_hidden.clone());
+                    stack.with_env(&orig_env_vars, &orig_env_hidden);
 
                     stack.add_var(
                         var_id,

--- a/crates/nu-command/src/core_commands/for_.rs
+++ b/crates/nu-command/src/core_commands/for_.rs
@@ -71,12 +71,16 @@ impl Command for For {
         let engine_state = engine_state.clone();
         let block = engine_state.get_block(block_id).clone();
         let mut stack = stack.collect_captures(&block.captures);
+        let orig_env_vars = stack.env_vars.clone();
+        let orig_env_hidden = stack.env_hidden.clone();
 
         match values {
             Value::List { vals, .. } => Ok(vals
                 .into_iter()
                 .enumerate()
                 .map(move |(idx, x)| {
+                    stack.with_env(orig_env_vars.clone(), orig_env_hidden.clone());
+
                     stack.add_var(
                         var_id,
                         if numbered {
@@ -107,6 +111,8 @@ impl Command for For {
                 .into_range_iter()?
                 .enumerate()
                 .map(move |(idx, x)| {
+                    stack.with_env(orig_env_vars.clone(), orig_env_hidden.clone());
+
                     stack.add_var(
                         var_id,
                         if numbered {

--- a/crates/nu-command/src/core_commands/hide.rs
+++ b/crates/nu-command/src/core_commands/hide.rs
@@ -98,12 +98,12 @@ impl Command for Hide {
                     return Err(ShellError::NonUtf8(import_pattern.span()));
                 };
 
-                if stack.remove_env_var(&name).is_none() {
+                if stack.remove_env_var(engine_state, &name).is_none() {
                     return Err(ShellError::NotFound(call.positional[0].span));
                 }
             }
         } else if !import_pattern.hidden.contains(&import_pattern.head.name)
-            && stack.remove_env_var(&head_name_str).is_none()
+            && stack.remove_env_var(engine_state, &head_name_str).is_none()
         {
             return Err(ShellError::NotFound(call.positional[0].span));
         }

--- a/crates/nu-command/src/dataframe/test_dataframe.rs
+++ b/crates/nu-command/src/dataframe/test_dataframe.rs
@@ -5,8 +5,6 @@ use nu_protocol::{
     PipelineData, Span, Value, CONFIG_VARIABLE_ID,
 };
 
-use std::collections::HashMap;
-
 use super::eager::ToDataFrame;
 use crate::Let;
 
@@ -35,7 +33,7 @@ pub fn test_dataframe(cmds: Vec<Box<dyn Command + 'static>>) {
     };
 
     let cwd = std::env::current_dir().expect("Could not get current working directory.");
-    let _ = engine_state.merge_delta(delta, &cwd, HashMap::new());
+    let _ = engine_state.merge_delta(delta, None, &cwd);
 
     for example in examples {
         // Skip tests that don't have results to compare to
@@ -55,7 +53,7 @@ pub fn test_dataframe(cmds: Vec<Box<dyn Command + 'static>>) {
             (output, working_set.render())
         };
 
-        let _ = engine_state.merge_delta(delta, &cwd, HashMap::new());
+        let _ = engine_state.merge_delta(delta, None, &cwd);
 
         let mut stack = Stack::new();
 

--- a/crates/nu-command/src/dataframe/test_dataframe.rs
+++ b/crates/nu-command/src/dataframe/test_dataframe.rs
@@ -5,6 +5,8 @@ use nu_protocol::{
     PipelineData, Span, Value, CONFIG_VARIABLE_ID,
 };
 
+use std::collections::HashMap;
+
 use super::eager::ToDataFrame;
 use crate::Let;
 
@@ -33,7 +35,7 @@ pub fn test_dataframe(cmds: Vec<Box<dyn Command + 'static>>) {
     };
 
     let cwd = std::env::current_dir().expect("Could not get current working directory.");
-    let _ = engine_state.merge_delta(delta, &cwd);
+    let _ = engine_state.merge_delta(delta, &cwd, HashMap::new());
 
     for example in examples {
         // Skip tests that don't have results to compare to
@@ -53,7 +55,7 @@ pub fn test_dataframe(cmds: Vec<Box<dyn Command + 'static>>) {
             (output, working_set.render())
         };
 
-        let _ = engine_state.merge_delta(delta, &cwd);
+        let _ = engine_state.merge_delta(delta, &cwd, HashMap::new());
 
         let mut stack = Stack::new();
 

--- a/crates/nu-command/src/dataframe/test_dataframe.rs
+++ b/crates/nu-command/src/dataframe/test_dataframe.rs
@@ -32,7 +32,8 @@ pub fn test_dataframe(cmds: Vec<Box<dyn Command + 'static>>) {
         working_set.render()
     };
 
-    let _ = engine_state.merge_delta(delta);
+    let cwd = std::env::current_dir().expect("Could not get current working directory.");
+    let _ = engine_state.merge_delta(delta, &cwd);
 
     for example in examples {
         // Skip tests that don't have results to compare to
@@ -52,7 +53,7 @@ pub fn test_dataframe(cmds: Vec<Box<dyn Command + 'static>>) {
             (output, working_set.render())
         };
 
-        let _ = engine_state.merge_delta(delta);
+        let _ = engine_state.merge_delta(delta, &cwd);
 
         let mut stack = Stack::new();
 

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -1,8 +1,9 @@
 use nu_protocol::engine::{EngineState, StateWorkingSet};
+use std::path::Path;
 
 use crate::*;
 
-pub fn create_default_context() -> EngineState {
+pub fn create_default_context(cwd: impl AsRef<Path>) -> EngineState {
     let mut engine_state = EngineState::new();
 
     let delta = {
@@ -306,7 +307,7 @@ pub fn create_default_context() -> EngineState {
         working_set.render()
     };
 
-    let _ = engine_state.merge_delta(delta);
+    let _ = engine_state.merge_delta(delta, &cwd);
 
     engine_state
 }

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -1,6 +1,5 @@
 use nu_protocol::engine::{EngineState, StateWorkingSet};
 
-use std::collections::HashMap;
 use std::path::Path;
 
 use crate::*;
@@ -309,7 +308,7 @@ pub fn create_default_context(cwd: impl AsRef<Path>) -> EngineState {
         working_set.render()
     };
 
-    let _ = engine_state.merge_delta(delta, &cwd, HashMap::new());
+    let _ = engine_state.merge_delta(delta, None, &cwd);
 
     engine_state
 }

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -1,4 +1,6 @@
 use nu_protocol::engine::{EngineState, StateWorkingSet};
+
+use std::collections::HashMap;
 use std::path::Path;
 
 use crate::*;
@@ -307,7 +309,7 @@ pub fn create_default_context(cwd: impl AsRef<Path>) -> EngineState {
         working_set.render()
     };
 
-    let _ = engine_state.merge_delta(delta, &cwd);
+    let _ = engine_state.merge_delta(delta, &cwd, HashMap::new());
 
     engine_state
 }

--- a/crates/nu-command/src/env/env_command.rs
+++ b/crates/nu-command/src/env/env_command.rs
@@ -29,7 +29,8 @@ impl Command for Env {
         let span = call.head;
         let config = stack.get_config().unwrap_or_default();
 
-        let mut env_vars: Vec<(String, Value)> = stack.get_env_vars().into_iter().collect();
+        let mut env_vars: Vec<(String, Value)> =
+            stack.get_env_vars(engine_state).into_iter().collect();
         env_vars.sort_by(|(name1, _), (name2, _)| name1.cmp(name2));
 
         let mut values = vec![];

--- a/crates/nu-command/src/example_test.rs
+++ b/crates/nu-command/src/example_test.rs
@@ -47,7 +47,8 @@ pub fn test_examples(cmd: impl Command + 'static) {
         working_set.render()
     };
 
-    let _ = engine_state.merge_delta(delta);
+    let cwd = std::env::current_dir().expect("Could not get current working directory.");
+    let _ = engine_state.merge_delta(delta, &cwd);
 
     for example in examples {
         // Skip tests that don't have results to compare to
@@ -67,7 +68,7 @@ pub fn test_examples(cmd: impl Command + 'static) {
             (output, working_set.render())
         };
 
-        let _ = engine_state.merge_delta(delta);
+        let _ = engine_state.merge_delta(delta, &cwd);
 
         let mut stack = Stack::new();
 

--- a/crates/nu-command/src/example_test.rs
+++ b/crates/nu-command/src/example_test.rs
@@ -7,6 +7,8 @@ use nu_protocol::{
     engine::{Command, EngineState, Stack, StateWorkingSet},
     PipelineData, Span, Value, CONFIG_VARIABLE_ID,
 };
+#[cfg(test)]
+use std::collections::HashMap;
 
 #[cfg(test)]
 use crate::To;
@@ -48,7 +50,7 @@ pub fn test_examples(cmd: impl Command + 'static) {
     };
 
     let cwd = std::env::current_dir().expect("Could not get current working directory.");
-    let _ = engine_state.merge_delta(delta, &cwd);
+    let _ = engine_state.merge_delta(delta, &cwd, HashMap::new());
 
     for example in examples {
         // Skip tests that don't have results to compare to
@@ -68,7 +70,7 @@ pub fn test_examples(cmd: impl Command + 'static) {
             (output, working_set.render())
         };
 
-        let _ = engine_state.merge_delta(delta, &cwd);
+        let _ = engine_state.merge_delta(delta, &cwd, HashMap::new());
 
         let mut stack = Stack::new();
 

--- a/crates/nu-command/src/example_test.rs
+++ b/crates/nu-command/src/example_test.rs
@@ -71,6 +71,23 @@ pub fn test_examples(cmd: impl Command + 'static) {
 
         let mut stack = Stack::new();
 
+        // Set up PWD
+        match std::env::current_dir() {
+            Ok(cwd) => stack.add_env_var(
+                "PWD".to_string(),
+                Value::String {
+                    val: cwd.to_string_lossy().to_string(),
+                    span: Span::test_data(),
+                },
+            ),
+            Err(e) => {
+                panic!(
+                    "Could not get current working directory. Got error: {:?}",
+                    e
+                )
+            }
+        }
+
         // Set up our initial config to start from
         stack.vars.insert(
             CONFIG_VARIABLE_ID,

--- a/crates/nu-command/src/example_test.rs
+++ b/crates/nu-command/src/example_test.rs
@@ -7,8 +7,6 @@ use nu_protocol::{
     engine::{Command, EngineState, Stack, StateWorkingSet},
     PipelineData, Span, Value, CONFIG_VARIABLE_ID,
 };
-#[cfg(test)]
-use std::collections::HashMap;
 
 #[cfg(test)]
 use crate::To;
@@ -50,7 +48,7 @@ pub fn test_examples(cmd: impl Command + 'static) {
     };
 
     let cwd = std::env::current_dir().expect("Could not get current working directory.");
-    let _ = engine_state.merge_delta(delta, &cwd, HashMap::new());
+    let _ = engine_state.merge_delta(delta, None, &cwd);
 
     for example in examples {
         // Skip tests that don't have results to compare to
@@ -70,7 +68,7 @@ pub fn test_examples(cmd: impl Command + 'static) {
             (output, working_set.render())
         };
 
-        let _ = engine_state.merge_delta(delta, &cwd, HashMap::new());
+        let _ = engine_state.merge_delta(delta, None, &cwd);
 
         let mut stack = Stack::new();
 

--- a/crates/nu-command/src/example_test.rs
+++ b/crates/nu-command/src/example_test.rs
@@ -73,21 +73,13 @@ pub fn test_examples(cmd: impl Command + 'static) {
         let mut stack = Stack::new();
 
         // Set up PWD
-        match std::env::current_dir() {
-            Ok(cwd) => stack.add_env_var(
-                "PWD".to_string(),
-                Value::String {
-                    val: cwd.to_string_lossy().to_string(),
-                    span: Span::test_data(),
-                },
-            ),
-            Err(e) => {
-                panic!(
-                    "Could not get current working directory. Got error: {:?}",
-                    e
-                )
-            }
-        }
+        stack.add_env_var(
+            "PWD".to_string(),
+            Value::String {
+                val: cwd.to_string_lossy().to_string(),
+                span: Span::test_data(),
+            },
+        );
 
         // Set up our initial config to start from
         stack.vars.insert(

--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -1,3 +1,4 @@
+use nu_engine::env::current_dir;
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
@@ -32,7 +33,10 @@ impl Command for Cd {
 
         let (path, span) = match path_val {
             Some(v) => {
-                let path = nu_path::canonicalize(v.as_string()?)?;
+                let path = nu_path::canonicalize_relative(
+                    v.as_string()?,
+                    current_dir(engine_state, &stack)?,
+                )?;
                 (path.to_string_lossy().to_string(), v.span()?)
             }
             None => {

--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -32,7 +32,7 @@ impl Command for Cd {
 
         let (path, span) = match path_val {
             Some(v) => {
-                let path = nu_path::expand_path(v.as_string()?);
+                let path = nu_path::canonicalize(v.as_string()?)?;
                 (path.to_string_lossy().to_string(), v.span()?)
             }
             None => {

--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -33,10 +33,8 @@ impl Command for Cd {
 
         let (path, span) = match path_val {
             Some(v) => {
-                let path = nu_path::canonicalize_relative(
-                    v.as_string()?,
-                    current_dir(engine_state, stack)?,
-                )?;
+                let path =
+                    nu_path::canonicalize_with(v.as_string()?, current_dir(engine_state, stack)?)?;
                 (path.to_string_lossy().to_string(), v.span()?)
             }
             None => {

--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -1,4 +1,4 @@
-use nu_engine::env::current_dir;
+use nu_engine::env::current_dir_str;
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
@@ -33,8 +33,10 @@ impl Command for Cd {
 
         let (path, span) = match path_val {
             Some(v) => {
-                let path =
-                    nu_path::canonicalize_with(v.as_string()?, current_dir(engine_state, stack)?)?;
+                let path = nu_path::canonicalize_with(
+                    v.as_string()?,
+                    current_dir_str(engine_state, stack)?,
+                )?;
                 (path.to_string_lossy().to_string(), v.span()?)
             }
             None => {

--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -40,7 +40,6 @@ impl Command for Cd {
                 (path.to_string_lossy().to_string(), call.head)
             }
         };
-        let _ = std::env::set_current_dir(&path);
 
         //FIXME: this only changes the current scope, but instead this environment variable
         //should probably be a block that loads the information from the state in the overlay

--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -35,7 +35,7 @@ impl Command for Cd {
             Some(v) => {
                 let path = nu_path::canonicalize_relative(
                     v.as_string()?,
-                    current_dir(engine_state, &stack)?,
+                    current_dir(engine_state, stack)?,
                 )?;
                 (path.to_string_lossy().to_string(), v.span()?)
             }

--- a/crates/nu-command/src/filesystem/cp.rs
+++ b/crates/nu-command/src/filesystem/cp.rs
@@ -1,7 +1,7 @@
-use std::env::current_dir;
 use std::path::PathBuf;
 
 use super::util::get_interactive_confirmation;
+use nu_engine::env::current_dir;
 use nu_engine::CallExt;
 use nu_path::canonicalize_with;
 use nu_protocol::ast::Call;
@@ -49,7 +49,7 @@ impl Command for Cp {
         let interactive = call.has_flag("interactive");
         let force = call.has_flag("force");
 
-        let path = current_dir()?;
+        let path = PathBuf::from(current_dir(engine_state, stack)?);
         let source = path.join(source.as_str());
         let destination = path.join(destination.as_str());
 
@@ -135,7 +135,7 @@ impl Command for Cp {
 
         for entry in sources.into_iter().flatten() {
             let mut sources = FileStructure::new();
-            sources.walk_decorate(&entry)?;
+            sources.walk_decorate(&entry, engine_state, stack)?;
 
             if entry.is_file() {
                 let sources = sources.paths_applying_with(|(source_file, _depth_level)| {

--- a/crates/nu-command/src/filesystem/cp.rs
+++ b/crates/nu-command/src/filesystem/cp.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use super::util::get_interactive_confirmation;
 use nu_engine::env::current_dir;
 use nu_engine::CallExt;
-use nu_path::canonicalize_with;
+use nu_path::canonicalize_relative;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{Category, PipelineData, ShellError, Signature, SyntaxShape};
@@ -140,7 +140,7 @@ impl Command for Cp {
             if entry.is_file() {
                 let sources = sources.paths_applying_with(|(source_file, _depth_level)| {
                     if destination.is_dir() {
-                        let mut dest = canonicalize_with(&destination, &path)?;
+                        let mut dest = canonicalize_relative(&destination, &path)?;
                         if let Some(name) = entry.file_name() {
                             dest.push(name);
                         }
@@ -188,7 +188,7 @@ impl Command for Cp {
 
                 let sources = sources.paths_applying_with(|(source_file, depth_level)| {
                     let mut dest = destination.clone();
-                    let path = canonicalize_with(&source_file, &path)?;
+                    let path = canonicalize_relative(&source_file, &path)?;
                     let components = path
                         .components()
                         .map(|fragment| fragment.as_os_str())

--- a/crates/nu-command/src/filesystem/cp.rs
+++ b/crates/nu-command/src/filesystem/cp.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use super::util::get_interactive_confirmation;
 use nu_engine::env::current_dir;
 use nu_engine::CallExt;
-use nu_path::canonicalize_relative;
+use nu_path::canonicalize_with;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{Category, PipelineData, ShellError, Signature, SyntaxShape};
@@ -140,7 +140,7 @@ impl Command for Cp {
             if entry.is_file() {
                 let sources = sources.paths_applying_with(|(source_file, _depth_level)| {
                     if destination.is_dir() {
-                        let mut dest = canonicalize_relative(&destination, &path)?;
+                        let mut dest = canonicalize_with(&destination, &path)?;
                         if let Some(name) = entry.file_name() {
                             dest.push(name);
                         }
@@ -188,7 +188,7 @@ impl Command for Cp {
 
                 let sources = sources.paths_applying_with(|(source_file, depth_level)| {
                     let mut dest = destination.clone();
-                    let path = canonicalize_relative(&source_file, &path)?;
+                    let path = canonicalize_with(&source_file, &path)?;
                     let components = path
                         .components()
                         .map(|fragment| fragment.as_os_str())

--- a/crates/nu-command/src/filesystem/cp.rs
+++ b/crates/nu-command/src/filesystem/cp.rs
@@ -49,7 +49,7 @@ impl Command for Cp {
         let interactive = call.has_flag("interactive");
         let force = call.has_flag("force");
 
-        let path = PathBuf::from(current_dir(engine_state, stack)?);
+        let path = current_dir(engine_state, stack)?;
         let source = path.join(source.as_str());
         let destination = path.join(destination.as_str());
 

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, Utc};
+use nu_engine::env::current_dir;
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
@@ -10,6 +11,7 @@ use nu_protocol::{
 use std::io::ErrorKind;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
 
 #[derive(Clone)]
 pub struct Ls;
@@ -63,10 +65,17 @@ impl Command for Ls {
 
         let call_span = call.head;
 
-        let pattern = if let Some(mut result) =
+        let (pattern, prefix) = if let Some(result) =
             call.opt::<Spanned<String>>(engine_state, stack, 0)?
         {
-            let path = std::path::Path::new(&result.item);
+            let path = PathBuf::from(&result.item);
+
+            let (mut path, prefix) = if path.is_relative() {
+                let cwd = current_dir(engine_state, stack)?;
+                (PathBuf::from(&cwd).join(path), Some(cwd))
+            } else {
+                (path, None)
+            };
 
             if path.is_dir() {
                 if permission_denied(&path) {
@@ -92,16 +101,17 @@ impl Command for Ls {
                 }
 
                 if path.is_dir() {
-                    if !result.item.ends_with(std::path::MAIN_SEPARATOR) {
-                        result.item.push(std::path::MAIN_SEPARATOR);
-                    }
-                    result.item.push('*');
+                    path = path.join("*");
                 }
             }
 
-            result.item
+            (path.to_string_lossy().to_string(), prefix)
         } else {
-            "*".into()
+            let cwd = current_dir(engine_state, stack)?;
+            (
+                PathBuf::from(&cwd).join("*").to_string_lossy().to_string(),
+                Some(cwd),
+            )
         };
 
         let glob = glob::glob(&pattern).map_err(|err| {
@@ -144,11 +154,34 @@ impl Command for Ls {
                         return None;
                     }
 
-                    let entry =
-                        dir_entry_dict(&path, metadata.as_ref(), call_span, long, short_names);
+                    let display_name = if short_names {
+                        path.file_name().and_then(|s| s.to_str())
+                    } else if let Some(pre) = &prefix {
+                        match path.strip_prefix(pre) {
+                            Ok(stripped) => stripped.to_str(),
+                            Err(_) => path.to_str(),
+                        }
+                    } else {
+                        path.to_str()
+                    }
+                    .ok_or_else(|| {
+                        ShellError::SpannedLabeledError(
+                            format!("Invalid file name: {:}", path.to_string_lossy()),
+                            "invalid file name".into(),
+                            call_span,
+                        )
+                    });
 
-                    match entry {
-                        Ok(value) => Some(value),
+                    match display_name {
+                        Ok(name) => {
+                            let entry =
+                                dir_entry_dict(&path, name, metadata.as_ref(), call_span, long);
+
+                            match entry {
+                                Ok(value) => Some(value),
+                                Err(err) => Some(Value::Error { error: err }),
+                            }
+                        }
                         Err(err) => Some(Value::Error { error: err }),
                     }
                 }
@@ -213,7 +246,7 @@ fn path_contains_hidden_folder(path: &Path, folders: &[PathBuf]) -> bool {
 
 #[cfg(unix)]
 use std::os::unix::fs::FileTypeExt;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 pub fn get_file_type(md: &std::fs::Metadata) -> &str {
     let ft = md.file_type();
@@ -243,31 +276,18 @@ pub fn get_file_type(md: &std::fs::Metadata) -> &str {
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn dir_entry_dict(
-    filename: &std::path::Path,
+    filename: &std::path::Path, // absolute path
+    display_name: &str,         // gile name to be displayed
     metadata: Option<&std::fs::Metadata>,
     span: Span,
     long: bool,
-    short_name: bool,
 ) -> Result<Value, ShellError> {
     let mut cols = vec![];
     let mut vals = vec![];
 
-    let name = if short_name {
-        filename.file_name().and_then(|s| s.to_str())
-    } else {
-        filename.to_str()
-    }
-    .ok_or_else(|| {
-        ShellError::SpannedLabeledError(
-            format!("Invalid file name: {:}", filename.to_string_lossy()),
-            "invalid file name".into(),
-            span,
-        )
-    })?;
-
     cols.push("name".into());
     vals.push(Value::String {
-        val: name.to_string(),
+        val: display_name.to_string(),
         span,
     });
 

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -72,7 +72,7 @@ impl Command for Ls {
 
             let (mut path, prefix) = if path.is_relative() {
                 let cwd = current_dir(engine_state, stack)?;
-                (PathBuf::from(&cwd).join(path), Some(cwd))
+                (cwd.join(path), Some(cwd))
             } else {
                 (path, None)
             };
@@ -108,10 +108,7 @@ impl Command for Ls {
             (path.to_string_lossy().to_string(), prefix)
         } else {
             let cwd = current_dir(engine_state, stack)?;
-            (
-                PathBuf::from(&cwd).join("*").to_string_lossy().to_string(),
-                Some(cwd),
-            )
+            (cwd.join("*").to_string_lossy().to_string(), Some(cwd))
         };
 
         let glob = glob::glob(&pattern).map_err(|err| {

--- a/crates/nu-command/src/filesystem/mkdir.rs
+++ b/crates/nu-command/src/filesystem/mkdir.rs
@@ -1,5 +1,4 @@
 use std::collections::VecDeque;
-use std::path::PathBuf;
 
 use nu_engine::env::current_dir;
 use nu_engine::CallExt;
@@ -40,7 +39,7 @@ impl Command for Mkdir {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        let path = PathBuf::from(current_dir(engine_state, stack)?);
+        let path = current_dir(engine_state, stack)?;
         let mut directories = call
             .rest::<String>(engine_state, stack, 0)?
             .into_iter()

--- a/crates/nu-command/src/filesystem/mkdir.rs
+++ b/crates/nu-command/src/filesystem/mkdir.rs
@@ -1,6 +1,7 @@
 use std::collections::VecDeque;
-use std::env::current_dir;
+use std::path::PathBuf;
 
+use nu_engine::env::current_dir;
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
@@ -39,7 +40,7 @@ impl Command for Mkdir {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        let path = current_dir()?;
+        let path = PathBuf::from(current_dir(engine_state, stack)?);
         let mut directories = call
             .rest::<String>(engine_state, stack, 0)?
             .into_iter()

--- a/crates/nu-command/src/filesystem/mv.rs
+++ b/crates/nu-command/src/filesystem/mv.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use super::util::get_interactive_confirmation;
 use nu_engine::env::current_dir;
@@ -50,7 +50,7 @@ impl Command for Mv {
         let interactive = call.has_flag("interactive");
         let force = call.has_flag("force");
 
-        let path = PathBuf::from(current_dir(engine_state, stack)?);
+        let path = current_dir(engine_state, stack)?;
         let source = path.join(spanned_source.item.as_str());
         let destination = path.join(destination.as_str());
 

--- a/crates/nu-command/src/filesystem/mv.rs
+++ b/crates/nu-command/src/filesystem/mv.rs
@@ -1,7 +1,7 @@
-use std::env::current_dir;
 use std::path::{Path, PathBuf};
 
 use super::util::get_interactive_confirmation;
+use nu_engine::env::current_dir;
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
@@ -50,7 +50,7 @@ impl Command for Mv {
         let interactive = call.has_flag("interactive");
         let force = call.has_flag("force");
 
-        let path: PathBuf = current_dir()?;
+        let path = PathBuf::from(current_dir(engine_state, stack)?);
         let source = path.join(spanned_source.item.as_str());
         let destination = path.join(destination.as_str());
 

--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -86,7 +86,7 @@ fn rm(
         ));
     }
 
-    let current_path = PathBuf::from(current_dir(engine_state, stack)?);
+    let current_path = current_dir(engine_state, stack)?;
     let mut paths = call
         .rest::<String>(engine_state, stack, 0)?
         .into_iter()

--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -1,10 +1,10 @@
-use std::env::current_dir;
 #[cfg(unix)]
 use std::os::unix::prelude::FileTypeExt;
 use std::path::PathBuf;
 
 use super::util::get_interactive_confirmation;
 
+use nu_engine::env::current_dir;
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
@@ -86,7 +86,7 @@ fn rm(
         ));
     }
 
-    let current_path = current_dir()?;
+    let current_path = PathBuf::from(current_dir(engine_state, stack)?);
     let mut paths = call
         .rest::<String>(engine_state, stack, 0)?
         .into_iter()

--- a/crates/nu-command/src/filesystem/touch.rs
+++ b/crates/nu-command/src/filesystem/touch.rs
@@ -1,11 +1,11 @@
 use std::fs::OpenOptions;
 
-use nu_engine::CallExt;
 use nu_engine::env::current_dir;
+use nu_engine::CallExt;
+use nu_path::expand_path_relative;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{Category, PipelineData, ShellError, Signature, SyntaxShape};
-use nu_path::expand_path_relative;
 
 #[derive(Clone)]
 pub struct Touch;
@@ -41,7 +41,7 @@ impl Command for Touch {
         let rest: Vec<String> = call.rest(engine_state, stack, 1)?;
 
         for (index, item) in vec![target].into_iter().chain(rest).enumerate() {
-            let path = expand_path_relative(&item, current_dir(engine_state, &stack)?);
+            let path = expand_path_relative(&item, current_dir(engine_state, stack)?);
             match OpenOptions::new().write(true).create(true).open(&path) {
                 Ok(_) => continue,
                 Err(err) => {

--- a/crates/nu-command/src/filesystem/touch.rs
+++ b/crates/nu-command/src/filesystem/touch.rs
@@ -1,9 +1,11 @@
 use std::fs::OpenOptions;
 
 use nu_engine::CallExt;
+use nu_engine::env::current_dir;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{Category, PipelineData, ShellError, Signature, SyntaxShape};
+use nu_path::expand_path_relative;
 
 #[derive(Clone)]
 pub struct Touch;
@@ -39,7 +41,8 @@ impl Command for Touch {
         let rest: Vec<String> = call.rest(engine_state, stack, 1)?;
 
         for (index, item) in vec![target].into_iter().chain(rest).enumerate() {
-            match OpenOptions::new().write(true).create(true).open(&item) {
+            let path = expand_path_relative(&item, current_dir(engine_state, &stack)?);
+            match OpenOptions::new().write(true).create(true).open(&path) {
                 Ok(_) => continue,
                 Err(err) => {
                     return Err(ShellError::CreateNotPossible(

--- a/crates/nu-command/src/filesystem/touch.rs
+++ b/crates/nu-command/src/filesystem/touch.rs
@@ -1,6 +1,6 @@
 use std::fs::OpenOptions;
 
-use nu_engine::env::current_dir;
+use nu_engine::env::current_dir_str;
 use nu_engine::CallExt;
 use nu_path::expand_path_with;
 use nu_protocol::ast::Call;
@@ -41,7 +41,7 @@ impl Command for Touch {
         let rest: Vec<String> = call.rest(engine_state, stack, 1)?;
 
         for (index, item) in vec![target].into_iter().chain(rest).enumerate() {
-            let path = expand_path_with(&item, current_dir(engine_state, stack)?);
+            let path = expand_path_with(&item, current_dir_str(engine_state, stack)?);
             match OpenOptions::new().write(true).create(true).open(&path) {
                 Ok(_) => continue,
                 Err(err) => {

--- a/crates/nu-command/src/filesystem/touch.rs
+++ b/crates/nu-command/src/filesystem/touch.rs
@@ -2,7 +2,7 @@ use std::fs::OpenOptions;
 
 use nu_engine::env::current_dir;
 use nu_engine::CallExt;
-use nu_path::expand_path_relative;
+use nu_path::expand_path_with;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{Category, PipelineData, ShellError, Signature, SyntaxShape};
@@ -41,7 +41,7 @@ impl Command for Touch {
         let rest: Vec<String> = call.rest(engine_state, stack, 1)?;
 
         for (index, item) in vec![target].into_iter().chain(rest).enumerate() {
-            let path = expand_path_relative(&item, current_dir(engine_state, stack)?);
+            let path = expand_path_with(&item, current_dir(engine_state, stack)?);
             match OpenOptions::new().write(true).create(true).open(&path) {
                 Ok(_) => continue,
                 Err(err) => {

--- a/crates/nu-command/src/filesystem/util.rs
+++ b/crates/nu-command/src/filesystem/util.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use nu_engine::env::current_dir;
+use nu_engine::env::current_dir_str;
 use nu_path::canonicalize_with;
 use nu_protocol::engine::{EngineState, Stack};
 use nu_protocol::ShellError;
@@ -61,7 +61,7 @@ impl FileStructure {
         engine_state: &EngineState,
         stack: &Stack,
     ) -> Result<(), ShellError> {
-        let source = canonicalize_with(src, current_dir(engine_state, stack)?)?;
+        let source = canonicalize_with(src, current_dir_str(engine_state, stack)?)?;
 
         if source.is_dir() {
             for entry in std::fs::read_dir(src)? {

--- a/crates/nu-command/src/filesystem/util.rs
+++ b/crates/nu-command/src/filesystem/util.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use nu_engine::env::current_dir;
-use nu_path::canonicalize_with;
+use nu_path::canonicalize_relative;
 use nu_protocol::engine::{EngineState, Stack};
 use nu_protocol::ShellError;
 
@@ -61,7 +61,7 @@ impl FileStructure {
         engine_state: &EngineState,
         stack: &Stack,
     ) -> Result<(), ShellError> {
-        let source = canonicalize_with(src, current_dir(engine_state, stack)?)?;
+        let source = canonicalize_relative(src, current_dir(engine_state, stack)?)?;
 
         if source.is_dir() {
             for entry in std::fs::read_dir(src)? {

--- a/crates/nu-command/src/filesystem/util.rs
+++ b/crates/nu-command/src/filesystem/util.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use nu_engine::env::current_dir;
-use nu_path::canonicalize_relative;
+use nu_path::canonicalize_with;
 use nu_protocol::engine::{EngineState, Stack};
 use nu_protocol::ShellError;
 
@@ -61,7 +61,7 @@ impl FileStructure {
         engine_state: &EngineState,
         stack: &Stack,
     ) -> Result<(), ShellError> {
-        let source = canonicalize_relative(src, current_dir(engine_state, stack)?)?;
+        let source = canonicalize_with(src, current_dir(engine_state, stack)?)?;
 
         if source.is_dir() {
             for entry in std::fs::read_dir(src)? {

--- a/crates/nu-command/src/filesystem/util.rs
+++ b/crates/nu-command/src/filesystem/util.rs
@@ -1,6 +1,8 @@
 use std::path::{Path, PathBuf};
 
+use nu_engine::env::current_dir;
 use nu_path::canonicalize_with;
+use nu_protocol::engine::{EngineState, Stack};
 use nu_protocol::ShellError;
 
 use dialoguer::Input;
@@ -39,16 +41,27 @@ impl FileStructure {
             .collect()
     }
 
-    pub fn walk_decorate(&mut self, start_path: &Path) -> Result<(), ShellError> {
+    pub fn walk_decorate(
+        &mut self,
+        start_path: &Path,
+        engine_state: &EngineState,
+        stack: &Stack,
+    ) -> Result<(), ShellError> {
         self.resources = Vec::<Resource>::new();
-        self.build(start_path, 0)?;
+        self.build(start_path, 0, engine_state, stack)?;
         self.resources.sort();
 
         Ok(())
     }
 
-    fn build(&mut self, src: &Path, lvl: usize) -> Result<(), ShellError> {
-        let source = canonicalize_with(src, std::env::current_dir()?)?;
+    fn build(
+        &mut self,
+        src: &Path,
+        lvl: usize,
+        engine_state: &EngineState,
+        stack: &Stack,
+    ) -> Result<(), ShellError> {
+        let source = canonicalize_with(src, current_dir(engine_state, stack)?)?;
 
         if source.is_dir() {
             for entry in std::fs::read_dir(src)? {
@@ -56,7 +69,7 @@ impl FileStructure {
                 let path = entry.path();
 
                 if path.is_dir() {
-                    self.build(&path, lvl + 1)?;
+                    self.build(&path, lvl + 1, engine_state, stack)?;
                 }
 
                 self.resources.push(Resource {

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -80,6 +80,8 @@ impl Command for Each {
                 .into_iter()
                 .enumerate()
                 .map(move |(idx, x)| {
+                    let mut stack = stack.clone();
+
                     if let Some(var) = block.signature.get_positional(0) {
                         if let Some(var_id) = &var.var_id {
                             if numbered {

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -115,6 +115,8 @@ impl Command for Each {
                 .into_iter()
                 .enumerate()
                 .map(move |(idx, x)| {
+                    let mut stack = stack.clone();
+
                     let x = match x {
                         Ok(x) => Value::Binary { val: x, span },
                         Err(err) => return Value::Error { error: err },
@@ -153,6 +155,8 @@ impl Command for Each {
                 .into_iter()
                 .enumerate()
                 .map(move |(idx, x)| {
+                    let mut stack = stack.clone();
+
                     let x = match x {
                         Ok(x) => Value::String { val: x, span },
                         Err(err) => return Value::Error { error: err },

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -82,7 +82,7 @@ impl Command for Each {
                 .into_iter()
                 .enumerate()
                 .map(move |(idx, x)| {
-                    stack.with_env(orig_env_vars.clone(), orig_env_hidden.clone());
+                    stack.with_env(&orig_env_vars, &orig_env_hidden);
 
                     if let Some(var) = block.signature.get_positional(0) {
                         if let Some(var_id) = &var.var_id {
@@ -117,7 +117,7 @@ impl Command for Each {
                 .into_iter()
                 .enumerate()
                 .map(move |(idx, x)| {
-                    stack.with_env(orig_env_vars.clone(), orig_env_hidden.clone());
+                    stack.with_env(&orig_env_vars, &orig_env_hidden);
 
                     let x = match x {
                         Ok(x) => Value::Binary { val: x, span },
@@ -157,7 +157,7 @@ impl Command for Each {
                 .into_iter()
                 .enumerate()
                 .map(move |(idx, x)| {
-                    stack.with_env(orig_env_vars.clone(), orig_env_hidden.clone());
+                    stack.with_env(&orig_env_vars, &orig_env_hidden);
 
                     let x = match x {
                         Ok(x) => Value::String { val: x, span },
@@ -200,7 +200,7 @@ impl Command for Each {
                 for (col, val) in cols.into_iter().zip(vals.into_iter()) {
                     let block = engine_state.get_block(block_id);
 
-                    stack.with_env(orig_env_vars.clone(), orig_env_hidden.clone());
+                    stack.with_env(&orig_env_vars, &orig_env_hidden);
 
                     if let Some(var) = block.signature.get_positional(0) {
                         if let Some(var_id) = &var.var_id {

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -71,6 +71,8 @@ impl Command for Each {
         let engine_state = engine_state.clone();
         let block = engine_state.get_block(block_id).clone();
         let mut stack = stack.collect_captures(&block.captures);
+        let orig_env_vars = stack.env_vars.clone();
+        let orig_env_hidden = stack.env_hidden.clone();
         let span = call.head;
 
         match input {
@@ -80,7 +82,7 @@ impl Command for Each {
                 .into_iter()
                 .enumerate()
                 .map(move |(idx, x)| {
-                    let mut stack = stack.clone();
+                    stack.with_env(orig_env_vars.clone(), orig_env_hidden.clone());
 
                     if let Some(var) = block.signature.get_positional(0) {
                         if let Some(var_id) = &var.var_id {
@@ -115,7 +117,7 @@ impl Command for Each {
                 .into_iter()
                 .enumerate()
                 .map(move |(idx, x)| {
-                    let mut stack = stack.clone();
+                    stack.with_env(orig_env_vars.clone(), orig_env_hidden.clone());
 
                     let x = match x {
                         Ok(x) => Value::Binary { val: x, span },
@@ -155,7 +157,7 @@ impl Command for Each {
                 .into_iter()
                 .enumerate()
                 .map(move |(idx, x)| {
-                    let mut stack = stack.clone();
+                    stack.with_env(orig_env_vars.clone(), orig_env_hidden.clone());
 
                     let x = match x {
                         Ok(x) => Value::String { val: x, span },
@@ -198,7 +200,7 @@ impl Command for Each {
                 for (col, val) in cols.into_iter().zip(vals.into_iter()) {
                     let block = engine_state.get_block(block_id);
 
-                    let mut stack = stack.clone();
+                    stack.with_env(orig_env_vars.clone(), orig_env_hidden.clone());
 
                     if let Some(var) = block.signature.get_positional(0) {
                         if let Some(var_id) = &var.var_id {

--- a/crates/nu-command/src/filters/update.rs
+++ b/crates/nu-command/src/filters/update.rs
@@ -74,9 +74,13 @@ fn update(
         let block = engine_state.get_block(block_id).clone();
 
         let mut stack = stack.collect_captures(&block.captures);
+        let orig_env_vars = stack.env_vars.clone();
+        let orig_env_hidden = stack.env_hidden.clone();
 
         input.map(
             move |mut input| {
+                stack.with_env(orig_env_vars.clone(), orig_env_hidden.clone());
+
                 if let Some(var) = block.signature.get_positional(0) {
                     if let Some(var_id) = &var.var_id {
                         stack.add_var(*var_id, input.clone())

--- a/crates/nu-command/src/filters/update.rs
+++ b/crates/nu-command/src/filters/update.rs
@@ -79,7 +79,7 @@ fn update(
 
         input.map(
             move |mut input| {
-                stack.with_env(orig_env_vars.clone(), orig_env_hidden.clone());
+                stack.with_env(&orig_env_vars, &orig_env_hidden);
 
                 if let Some(var) = block.signature.get_positional(0) {
                     if let Some(var_id) = &var.var_id {

--- a/crates/nu-command/src/path/expand.rs
+++ b/crates/nu-command/src/path/expand.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use nu_engine::env::current_dir;
+use nu_engine::env::current_dir_str;
 use nu_engine::CallExt;
 use nu_path::{canonicalize_with, expand_path};
 use nu_protocol::{engine::Command, Example, ShellError, Signature, Span, SyntaxShape, Value};
@@ -57,7 +57,7 @@ impl Command for SubCommand {
         let args = Arguments {
             strict: call.has_flag("strict"),
             columns: call.get_flag(engine_state, stack, "columns")?,
-            cwd: current_dir(engine_state, stack)?,
+            cwd: current_dir_str(engine_state, stack)?,
         };
 
         input.map(

--- a/crates/nu-command/src/path/expand.rs
+++ b/crates/nu-command/src/path/expand.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use nu_engine::env::current_dir;
 use nu_engine::CallExt;
-use nu_path::{canonicalize_relative, expand_path};
+use nu_path::{canonicalize_with, expand_path};
 use nu_protocol::{engine::Command, Example, ShellError, Signature, Span, SyntaxShape, Value};
 
 use super::PathSubcommandArguments;
@@ -110,7 +110,7 @@ impl Command for SubCommand {
 }
 
 fn expand(path: &Path, span: Span, args: &Arguments) -> Value {
-    if let Ok(p) = canonicalize_relative(path, &args.cwd) {
+    if let Ok(p) = canonicalize_with(path, &args.cwd) {
         Value::string(p.to_string_lossy(), span)
     } else if args.strict {
         Value::Error {

--- a/crates/nu-command/src/path/expand.rs
+++ b/crates/nu-command/src/path/expand.rs
@@ -1,7 +1,8 @@
 use std::path::Path;
 
 use nu_engine::CallExt;
-use nu_path::{canonicalize, expand_path};
+use nu_engine::env::current_dir;
+use nu_path::{canonicalize_relative, expand_path};
 use nu_protocol::{engine::Command, Example, ShellError, Signature, Span, SyntaxShape, Value};
 
 use super::PathSubcommandArguments;
@@ -9,6 +10,7 @@ use super::PathSubcommandArguments;
 struct Arguments {
     strict: bool,
     columns: Option<Vec<String>>,
+    cwd: String,
 }
 
 impl PathSubcommandArguments for Arguments {
@@ -55,6 +57,7 @@ impl Command for SubCommand {
         let args = Arguments {
             strict: call.has_flag("strict"),
             columns: call.get_flag(engine_state, stack, "columns")?,
+            cwd: current_dir(engine_state, &stack)?,
         };
 
         input.map(
@@ -107,7 +110,7 @@ impl Command for SubCommand {
 }
 
 fn expand(path: &Path, span: Span, args: &Arguments) -> Value {
-    if let Ok(p) = canonicalize(path) {
+    if let Ok(p) = canonicalize_relative(path, &args.cwd) {
         Value::string(p.to_string_lossy(), span)
     } else if args.strict {
         Value::Error {

--- a/crates/nu-command/src/path/expand.rs
+++ b/crates/nu-command/src/path/expand.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
-use nu_engine::CallExt;
 use nu_engine::env::current_dir;
+use nu_engine::CallExt;
 use nu_path::{canonicalize_relative, expand_path};
 use nu_protocol::{engine::Command, Example, ShellError, Signature, Span, SyntaxShape, Value};
 
@@ -57,7 +57,7 @@ impl Command for SubCommand {
         let args = Arguments {
             strict: call.has_flag("strict"),
             columns: call.get_flag(engine_state, stack, "columns")?,
-            cwd: current_dir(engine_state, &stack)?,
+            cwd: current_dir(engine_state, stack)?,
         };
 
         input.map(

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::env;
 use std::io::{BufRead, BufReader, Write};
+use std::path::Path;
 use std::process::{Command as CommandSys, Stdio};
 use std::sync::atomic::Ordering;
 use std::sync::mpsc;
@@ -113,9 +114,19 @@ impl<'call> ExternalCommand<'call> {
 
         // TODO. We don't have a way to know the current directory
         // This should be information from the EvaluationContex or EngineState
-        let path = env::current_dir()?;
-
-        process.current_dir(path);
+        if let Some(d) = self.env_vars.get("PWD") {
+            process.current_dir(d);
+        } else {
+            return Err(ShellError::SpannedLabeledErrorHelp(
+                "Current directory not found".to_string(),
+                "did not find PWD environment variable".to_string(),
+                head,
+                concat!(
+                    "The environment variable 'PWD' was not found. ",
+                    "It is required to define the current directory when running an external command."
+                ).to_string(),
+            ));
+        }
 
         process.envs(&self.env_vars);
 

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -1,7 +1,5 @@
 use std::collections::HashMap;
-use std::env;
 use std::io::{BufRead, BufReader, Write};
-use std::path::Path;
 use std::process::{Command as CommandSys, Stdio};
 use std::sync::atomic::Ordering;
 use std::sync::mpsc;

--- a/crates/nu-command/src/viewers/griddle.rs
+++ b/crates/nu-command/src/viewers/griddle.rs
@@ -62,7 +62,7 @@ prints out the list properly."#
         let color_param: bool = call.has_flag("color");
         let separator_param: Option<String> = call.get_flag(engine_state, stack, "separator")?;
         let config = stack.get_config().unwrap_or_default();
-        let env_str = match stack.get_env_var("LS_COLORS") {
+        let env_str = match stack.get_env_var(engine_state, "LS_COLORS") {
             Some(v) => Some(env_to_string("LS_COLORS", v, engine_state, stack, &config)?),
             None => None,
         };

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -112,7 +112,7 @@ impl Command for Table {
                         let config = config.clone();
                         let ctrlc = ctrlc.clone();
 
-                        let ls_colors = match stack.get_env_var("LS_COLORS") {
+                        let ls_colors = match stack.get_env_var(engine_state, "LS_COLORS") {
                             Some(v) => LsColors::from_string(&env_to_string(
                                 "LS_COLORS",
                                 v,

--- a/crates/nu-engine/src/env.rs
+++ b/crates/nu-engine/src/env.rs
@@ -89,7 +89,7 @@ pub fn env_to_string(
     env_name: &str,
     value: Value,
     engine_state: &EngineState,
-    stack: &mut Stack,
+    stack: &Stack,
     config: &Config,
 ) -> Result<String, ShellError> {
     if let Some(env_conv) = config.env_conversions.get(env_name) {
@@ -128,7 +128,7 @@ pub fn env_to_string(
 /// Translate all environment variables from Values to Strings
 pub fn env_to_strings(
     engine_state: &EngineState,
-    stack: &mut Stack,
+    stack: &Stack,
     config: &Config,
 ) -> Result<HashMap<String, String>, ShellError> {
     let env_vars = stack.get_env_vars();
@@ -139,4 +139,17 @@ pub fn env_to_strings(
     }
 
     Ok(env_vars_str)
+}
+
+/// Shorthand for env_to_string() for PWD with custom error
+pub fn current_dir(engine_state: &EngineState, stack: &Stack) -> Result<String, ShellError> {
+    let config = stack.get_config()?;
+    if let Some(pwd) = stack.get_env_var("PWD") {
+        env_to_string("PWD", pwd, engine_state, stack, &config)
+    } else {
+        Err(ShellError::LabeledError(
+            "Current directory not found".to_string(),
+            "The environment variable 'PWD' was not found. It is required to define the current directory.".to_string(),
+        ))
+    }
 }

--- a/crates/nu-engine/src/env.rs
+++ b/crates/nu-engine/src/env.rs
@@ -132,7 +132,7 @@ pub fn env_to_strings(
     stack: &Stack,
     config: &Config,
 ) -> Result<HashMap<String, String>, ShellError> {
-    let env_vars = stack.get_env_vars();
+    let env_vars = stack.get_env_vars(engine_state);
     let mut env_vars_str = HashMap::new();
     for (env_name, val) in env_vars {
         let val_str = env_to_string(&env_name, val, engine_state, stack, config)?;
@@ -145,7 +145,7 @@ pub fn env_to_strings(
 /// Shorthand for env_to_string() for PWD with custom error
 pub fn current_dir(engine_state: &EngineState, stack: &Stack) -> Result<String, ShellError> {
     let config = stack.get_config()?;
-    if let Some(pwd) = stack.get_env_var("PWD") {
+    if let Some(pwd) = stack.get_env_var(engine_state, "PWD") {
         match env_to_string("PWD", pwd, engine_state, stack, &config) {
             Ok(cwd) => {
                 if Path::new(&cwd).is_absolute() {

--- a/crates/nu-engine/src/env.rs
+++ b/crates/nu-engine/src/env.rs
@@ -22,10 +22,8 @@ pub fn convert_env_values(
     stack: &Stack,
     config: &Config,
 ) -> Option<ShellError> {
-    // let mut new_env_vars = vec![];
     let mut error = None;
 
-    // for scope in &stack.env_vars {
     let mut new_scope = HashMap::new();
 
     for (name, val) in &engine_state.env_vars {
@@ -76,11 +74,6 @@ pub fn convert_env_values(
     for (k, v) in new_scope {
         engine_state.env_vars.insert(k, v);
     }
-
-    //     new_env_vars.push(new_scope);
-    // }
-
-    // stack.env_vars = new_env_vars;
 
     error
 }

--- a/crates/nu-engine/src/env.rs
+++ b/crates/nu-engine/src/env.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use nu_protocol::engine::{EngineState, Stack};
 use nu_protocol::{Config, PipelineData, ShellError, Value};
@@ -136,7 +136,7 @@ pub fn env_to_strings(
 }
 
 /// Shorthand for env_to_string() for PWD with custom error
-pub fn current_dir(engine_state: &EngineState, stack: &Stack) -> Result<String, ShellError> {
+pub fn current_dir_str(engine_state: &EngineState, stack: &Stack) -> Result<String, ShellError> {
     let config = stack.get_config()?;
     if let Some(pwd) = stack.get_env_var(engine_state, "PWD") {
         match env_to_string("PWD", pwd, engine_state, stack, &config) {
@@ -158,4 +158,9 @@ pub fn current_dir(engine_state: &EngineState, stack: &Stack) -> Result<String, 
                 "The environment variable 'PWD' was not found. It is required to define the current directory.".to_string(),
         ))
     }
+}
+
+/// Calls current_dir_str() and returns the current directory as a PathBuf
+pub fn current_dir(engine_state: &EngineState, stack: &Stack) -> Result<PathBuf, ShellError> {
+    current_dir_str(engine_state, stack).map(PathBuf::from)
 }

--- a/crates/nu-engine/src/env.rs
+++ b/crates/nu-engine/src/env.rs
@@ -18,17 +18,17 @@ const ENV_SEP: &str = ":";
 /// skip errors. This function is called in the main() so we want to keep running, we cannot just
 /// exit.
 pub fn convert_env_values(
-    engine_state: &EngineState,
+    engine_state: &mut EngineState,
     stack: &mut Stack,
     config: &Config,
 ) -> Option<ShellError> {
-    let mut new_env_vars = vec![];
+    // let mut new_env_vars = vec![];
     let mut error = None;
 
-    for scope in &stack.env_vars {
+    // for scope in &stack.env_vars {
         let mut new_scope = HashMap::new();
 
-        for (name, val) in scope {
+        for (name, val) in &engine_state.env_vars {
             if let Some(env_conv) = config.env_conversions.get(name) {
                 if let Some((block_id, from_span)) = env_conv.from_string {
                     let val_span = match val.span() {
@@ -77,10 +77,14 @@ pub fn convert_env_values(
             }
         }
 
-        new_env_vars.push(new_scope);
-    }
+        for (k, v) in new_scope {
+            engine_state.env_vars.insert(k, v);
+        }
 
-    stack.env_vars = new_env_vars;
+    //     new_env_vars.push(new_scope);
+    // }
+
+    // stack.env_vars = new_env_vars;
 
     error
 }

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -8,7 +8,7 @@ use nu_protocol::{
     Spanned, Type, Unit, Value, VarId, ENV_VARIABLE_ID,
 };
 
-use crate::get_full_help;
+use crate::{current_dir, get_full_help};
 
 pub fn eval_operator(op: &Expression) -> Result<Operator, ShellError> {
     match op {
@@ -575,15 +575,9 @@ pub fn eval_variable(
 
         // since the env var PWD doesn't exist on all platforms
         // lets just get the current directory
-        if let Ok(current_dir) = std::env::current_dir() {
-            if let Some(cwd) = current_dir.to_str() {
-                output_cols.push("cwd".into());
-                output_vals.push(Value::String {
-                    val: cwd.into(),
-                    span,
-                })
-            }
-        }
+        let cwd = current_dir(engine_state, stack)?;
+        output_cols.push("cwd".into());
+        output_vals.push(Value::String { val: cwd, span });
 
         if let Some(home_path) = nu_path::home_dir() {
             if let Some(home_path_str) = home_path.to_str() {

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -880,7 +880,7 @@ pub fn eval_variable(
             span,
         })
     } else if var_id == ENV_VARIABLE_ID {
-        let env_vars = stack.get_env_vars();
+        let env_vars = stack.get_env_vars(engine_state);
         let env_columns = env_vars.keys();
         let env_values = env_vars.values();
 

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -8,7 +8,7 @@ use nu_protocol::{
     Spanned, Type, Unit, Value, VarId, ENV_VARIABLE_ID,
 };
 
-use crate::{current_dir, get_full_help};
+use crate::{current_dir_str, get_full_help};
 
 pub fn eval_operator(op: &Expression) -> Result<Operator, ShellError> {
     match op {
@@ -575,7 +575,7 @@ pub fn eval_variable(
 
         // since the env var PWD doesn't exist on all platforms
         // lets just get the current directory
-        let cwd = current_dir(engine_state, stack)?;
+        let cwd = current_dir_str(engine_state, stack)?;
         output_cols.push("cwd".into());
         output_vals.push(Value::String { val: cwd, span });
 

--- a/crates/nu-engine/src/lib.rs
+++ b/crates/nu-engine/src/lib.rs
@@ -1,7 +1,7 @@
 mod call_ext;
 pub mod column;
 mod documentation;
-mod env;
+pub mod env;
 mod eval;
 
 pub use call_ext::CallExt;

--- a/crates/nu-path/src/expansions.rs
+++ b/crates/nu-path/src/expansions.rs
@@ -39,7 +39,7 @@ pub fn canonicalize(path: impl AsRef<Path>) -> io::Result<PathBuf> {
 }
 
 /// Same as canonicalize() but the input path is specified relative to another path
-pub fn canonicalize_relative<P, Q>(path: P, relative_to: Q) -> io::Result<PathBuf>
+pub fn canonicalize_with<P, Q>(path: P, relative_to: Q) -> io::Result<PathBuf>
 where
     P: AsRef<Path>,
     Q: AsRef<Path>,
@@ -64,7 +64,7 @@ pub fn expand_path(path: impl AsRef<Path>) -> PathBuf {
 }
 
 /// Same as expand_path() but the input path is specified relative to another path
-pub fn expand_path_relative<P, Q>(path: P, relative_to: Q) -> PathBuf
+pub fn expand_path_with<P, Q>(path: P, relative_to: Q) -> PathBuf
 where
     P: AsRef<Path>,
     Q: AsRef<Path>,

--- a/crates/nu-path/src/expansions.rs
+++ b/crates/nu-path/src/expansions.rs
@@ -39,7 +39,7 @@ pub fn canonicalize(path: impl AsRef<Path>) -> io::Result<PathBuf> {
 }
 
 /// Same as canonicalize() but the input path is specified relative to another path
-pub fn canonicalize_with<P, Q>(path: P, relative_to: Q) -> io::Result<PathBuf>
+pub fn canonicalize_relative<P, Q>(path: P, relative_to: Q) -> io::Result<PathBuf>
 where
     P: AsRef<Path>,
     Q: AsRef<Path>,
@@ -64,7 +64,7 @@ pub fn expand_path(path: impl AsRef<Path>) -> PathBuf {
 }
 
 /// Same as expand_path() but the input path is specified relative to another path
-pub fn expand_path_with<P, Q>(path: P, relative_to: Q) -> PathBuf
+pub fn expand_path_relative<P, Q>(path: P, relative_to: Q) -> PathBuf
 where
     P: AsRef<Path>,
     Q: AsRef<Path>,

--- a/crates/nu-path/src/lib.rs
+++ b/crates/nu-path/src/lib.rs
@@ -4,7 +4,7 @@ mod helpers;
 mod tilde;
 mod util;
 
-pub use expansions::{canonicalize, canonicalize_with, expand_path, expand_path_with};
+pub use expansions::{canonicalize, canonicalize_relative, expand_path, expand_path_relative};
 pub use helpers::{config_dir, home_dir};
 pub use tilde::expand_tilde;
 pub use util::trim_trailing_slash;

--- a/crates/nu-path/src/lib.rs
+++ b/crates/nu-path/src/lib.rs
@@ -4,7 +4,7 @@ mod helpers;
 mod tilde;
 mod util;
 
-pub use expansions::{canonicalize, canonicalize_relative, expand_path, expand_path_relative};
+pub use expansions::{canonicalize, canonicalize_with, expand_path, expand_path_with};
 pub use helpers::{config_dir, home_dir};
 pub use tilde::expand_tilde;
 pub use util::trim_trailing_slash;

--- a/crates/nu-path/src/tilde.rs
+++ b/crates/nu-path/src/tilde.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-fn expand_tilde_with(path: impl AsRef<Path>, home: Option<PathBuf>) -> PathBuf {
+fn expand_tilde_with_home(path: impl AsRef<Path>, home: Option<PathBuf>) -> PathBuf {
     let path = path.as_ref();
 
     if !path.starts_with("~") {
@@ -27,7 +27,7 @@ fn expand_tilde_with(path: impl AsRef<Path>, home: Option<PathBuf>) -> PathBuf {
 /// Expand tilde ("~") into a home directory if it is the first path component
 pub fn expand_tilde(path: impl AsRef<Path>) -> PathBuf {
     // TODO: Extend this to work with "~user" style of home paths
-    expand_tilde_with(path, dirs_next::home_dir())
+    expand_tilde_with_home(path, dirs_next::home_dir())
 }
 
 #[cfg(test)]
@@ -37,17 +37,17 @@ mod tests {
     fn check_expanded(s: &str) {
         let home = Path::new("/home");
         let buf = Some(PathBuf::from(home));
-        assert!(expand_tilde_with(Path::new(s), buf).starts_with(&home));
+        assert!(expand_tilde_with_home(Path::new(s), buf).starts_with(&home));
 
         // Tests the special case in expand_tilde for "/" as home
         let home = Path::new("/");
         let buf = Some(PathBuf::from(home));
-        assert!(!expand_tilde_with(Path::new(s), buf).starts_with("//"));
+        assert!(!expand_tilde_with_home(Path::new(s), buf).starts_with("//"));
     }
 
     fn check_not_expanded(s: &str) {
         let home = PathBuf::from("/home");
-        let expanded = expand_tilde_with(Path::new(s), Some(home));
+        let expanded = expand_tilde_with_home(Path::new(s), Some(home));
         assert!(expanded == Path::new(s));
     }
 

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -189,6 +189,7 @@ impl EngineState {
         &mut self,
         mut delta: StateDelta,
         cwd: impl AsRef<Path>,
+        env_vars: HashMap<String, Value>,
     ) -> Result<(), ShellError> {
         // Take the mutable reference and extend the permanent state from the working set
         self.files.extend(delta.files);
@@ -197,6 +198,10 @@ impl EngineState {
         self.vars.extend(delta.vars);
         self.blocks.extend(delta.blocks);
         self.overlays.extend(delta.overlays);
+
+        for (k, v) in env_vars {
+            self.env_vars.insert(k, v);
+        }
 
         std::env::set_current_dir(cwd)?;
 
@@ -1222,7 +1227,7 @@ mod engine_state_tests {
         };
 
         let cwd = std::env::current_dir().expect("Could not get current working directory.");
-        engine_state.merge_delta(delta, &cwd)?;
+        engine_state.merge_delta(delta, &cwd, HashMap::new())?;
 
         assert_eq!(engine_state.num_files(), 2);
         assert_eq!(&engine_state.files[0].0, "test.nu");

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -9,6 +9,8 @@ use std::{
     sync::{atomic::AtomicBool, Arc},
 };
 
+use crate::Value;
+
 use std::path::Path;
 
 #[cfg(feature = "plugin")]
@@ -142,6 +144,7 @@ pub struct EngineState {
     overlays: im::Vector<Overlay>,
     pub scope: im::Vector<ScopeFrame>,
     pub ctrlc: Option<Arc<AtomicBool>>,
+    pub env_vars: im::HashMap<String, Value>,
     #[cfg(feature = "plugin")]
     pub plugin_signatures: Option<PathBuf>,
 }
@@ -169,6 +172,7 @@ impl EngineState {
             overlays: im::vector![],
             scope: im::vector![ScopeFrame::new()],
             ctrlc: None,
+            env_vars: im::HashMap::new(),
             #[cfg(feature = "plugin")]
             plugin_signatures: None,
         }

--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -46,9 +46,14 @@ impl Stack {
         }
     }
 
-    pub fn with_env(&mut self, env_vars: Vec<HashMap<String, Value>>, env_hidden: HashSet<String>) {
-        self.env_vars = env_vars;
-        self.env_hidden = env_hidden;
+    pub fn with_env(&mut self, env_vars: &[HashMap<String, Value>], env_hidden: &HashSet<String>) {
+        if env_vars.iter().any(|scope| !scope.is_empty()) {
+            self.env_vars = env_vars.to_owned();
+        }
+
+        if !env_hidden.is_empty() {
+            self.env_hidden = env_hidden.clone();
+        }
     }
 
     pub fn get_var(&self, var_id: VarId) -> Result<Value, ShellError> {

--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -99,7 +99,8 @@ impl Stack {
 
     /// Flatten the env var scope frames into one frame
     pub fn get_env_vars(&self, engine_state: &EngineState) -> HashMap<String, Value> {
-        // TODO: Collecting im::HashMap into regular HashMap... maybe we could try im here as well.
+        // TODO: We're collecting im::HashMap to HashMap here. It might make sense to make these
+        // the same data structure.
         let mut result: HashMap<String, Value> = engine_state
             .env_vars
             .iter()
@@ -121,14 +122,14 @@ impl Stack {
             }
         }
 
-        if let Some(val) = engine_state.env_vars.get(name) {
-            if self.env_hidden.contains(name) {
-                None
-            } else {
-                Some(val.clone())
-            }
-        } else {
+        if self.env_hidden.contains(name) {
             None
+        } else {
+            if let Some(val) = engine_state.env_vars.get(name) {
+                Some(val.clone())
+            } else {
+                None
+            }
         }
     }
 

--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -140,13 +140,18 @@ impl Stack {
             }
         }
 
-        if let Some(val) = engine_state.env_vars.get(name) {
-            // the environment variable was found in the engine state => mark it as hidden
-            self.env_hidden.insert(name.to_string());
-            return Some(val.clone());
+        if self.env_hidden.contains(name) {
+            // the environment variable is already hidden
+            None
+        } else {
+            if let Some(val) = engine_state.env_vars.get(name) {
+                // the environment variable was found in the engine state => mark it as hidden
+                self.env_hidden.insert(name.to_string());
+                Some(val.clone())
+            } else {
+                None
+            }
         }
-
-        None
     }
 
     pub fn get_config(&self) -> Result<Config, ShellError> {

--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -46,6 +46,11 @@ impl Stack {
         }
     }
 
+    pub fn with_env(&mut self, env_vars: Vec<HashMap<String, Value>>, env_hidden: HashSet<String>) {
+        self.env_vars = env_vars;
+        self.env_hidden = env_hidden;
+    }
+
     pub fn get_var(&self, var_id: VarId) -> Result<Value, ShellError> {
         if let Some(v) = self.vars.get(&var_id) {
             return Ok(v.clone());

--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -125,11 +125,7 @@ impl Stack {
         if self.env_hidden.contains(name) {
             None
         } else {
-            if let Some(val) = engine_state.env_vars.get(name) {
-                Some(val.clone())
-            } else {
-                None
-            }
+            engine_state.env_vars.get(name).cloned()
         }
     }
 
@@ -143,14 +139,12 @@ impl Stack {
         if self.env_hidden.contains(name) {
             // the environment variable is already hidden
             None
+        } else if let Some(val) = engine_state.env_vars.get(name) {
+            // the environment variable was found in the engine state => mark it as hidden
+            self.env_hidden.insert(name.to_string());
+            Some(val.clone())
         } else {
-            if let Some(val) = engine_state.env_vars.get(name) {
-                // the environment variable was found in the engine state => mark it as hidden
-                self.env_hidden.insert(name.to_string());
-                Some(val.clone())
-            } else {
-                None
-            }
+            None
         }
     }
 

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -96,12 +96,9 @@ pub enum ShellError {
     VariableNotFoundAtRuntime(#[label = "variable not found"] Span),
 
     #[error("Environment variable not found")]
-    #[diagnostic(code(nu::shell::variable_not_found), url(docsrs))]
+    #[diagnostic(code(nu::shell::env_variable_not_found), url(docsrs))]
     EnvVarNotFoundAtRuntime(#[label = "environment variable not found"] Span),
 
-    // #[error("Environment variable is not a string")]
-    // #[diagnostic(code(nu::shell::variable_not_found), url(docsrs))]
-    // EnvVarNotAString(#[label = "does not evaluate to a string"] Span),
     #[error("Not found.")]
     #[diagnostic(code(nu::parser::not_found), url(docsrs))]
     NotFound(#[label = "did not find anything under this name"] Span),

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -182,7 +182,7 @@ pub enum ShellError {
     PluginFailedToDecode(String),
 
     #[error("I/O error")]
-    #[diagnostic(code(nu::shell::io_error), url(docsrs))]
+    #[diagnostic(code(nu::shell::io_error), url(docsrs), help("{0}"))]
     IOError(String),
 
     #[error("Directory not found")]

--- a/crates/nu_plugin_gstat/src/gstat.rs
+++ b/crates/nu_plugin_gstat/src/gstat.rs
@@ -65,6 +65,9 @@ impl GStat {
         }
 
         // This path has to exist
+        // TODO: If the path is relative, it will be expanded using `std::env::current_dir` and not
+        // the "PWD" environment variable. We would need a way to read the engine's environment
+        // variables here.
         if !std::path::Path::new(&a_path.item).exists() {
             return Err(LabeledError {
                 label: "error with path".to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -762,23 +762,27 @@ fn print_pipeline_data(
     Ok(())
 }
 
-fn get_prompt_indicators(config: &Config, stack: &Stack) -> (String, String, String, String) {
-    let prompt_indicator = match stack.get_env_var(PROMPT_INDICATOR) {
+fn get_prompt_indicators(
+    config: &Config,
+    engine_state: &EngineState,
+    stack: &Stack,
+) -> (String, String, String, String) {
+    let prompt_indicator = match stack.get_env_var(engine_state, PROMPT_INDICATOR) {
         Some(pi) => pi.into_string("", config),
         None => "〉".to_string(),
     };
 
-    let prompt_vi_insert = match stack.get_env_var(PROMPT_INDICATOR_VI_INSERT) {
+    let prompt_vi_insert = match stack.get_env_var(engine_state, PROMPT_INDICATOR_VI_INSERT) {
         Some(pvii) => pvii.into_string("", config),
         None => ": ".to_string(),
     };
 
-    let prompt_vi_visual = match stack.get_env_var(PROMPT_INDICATOR_VI_VISUAL) {
+    let prompt_vi_visual = match stack.get_env_var(engine_state, PROMPT_INDICATOR_VI_VISUAL) {
         Some(pviv) => pviv.into_string("", config),
         None => "v ".to_string(),
     };
 
-    let prompt_multiline = match stack.get_env_var(PROMPT_MULTILINE_INDICATOR) {
+    let prompt_multiline = match stack.get_env_var(engine_state, PROMPT_MULTILINE_INDICATOR) {
         Some(pm) => pm.into_string("", config),
         None => "::: ".to_string(),
     };
@@ -803,9 +807,9 @@ fn update_prompt<'prompt>(
         prompt_vi_insert_string,
         prompt_vi_visual_string,
         prompt_multiline_string,
-    ) = get_prompt_indicators(config, stack);
+    ) = get_prompt_indicators(config, engine_state, stack);
 
-    let prompt_command_block_id = match stack.get_env_var(PROMPT_COMMAND) {
+    let prompt_command_block_id = match stack.get_env_var(engine_state, PROMPT_COMMAND) {
         Some(v) => match v.as_block() {
             Ok(b) => b,
             Err(_) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,7 +142,7 @@ fn main() -> Result<()> {
         let mut stack = nu_protocol::engine::Stack::new();
 
         // First, set up env vars as strings only
-        gather_parent_env_vars(&mut engine_state, &mut stack);
+        gather_parent_env_vars(&mut engine_state);
 
         // Set up our initial config to start from
         stack.vars.insert(
@@ -165,7 +165,7 @@ fn main() -> Result<()> {
         };
 
         // Translate environment variables from Strings to Values
-        if let Some(e) = convert_env_values(&mut engine_state, &mut stack, &config) {
+        if let Some(e) = convert_env_values(&mut engine_state, &stack, &config) {
             let working_set = StateWorkingSet::new(&engine_state);
             report_error(&working_set, &e);
             std::process::exit(1);
@@ -265,7 +265,7 @@ fn main() -> Result<()> {
         let mut stack = nu_protocol::engine::Stack::new();
 
         // First, set up env vars as strings only
-        gather_parent_env_vars(&mut engine_state, &mut stack);
+        gather_parent_env_vars(&mut engine_state);
 
         // Set up our initial config to start from
         stack.vars.insert(
@@ -341,7 +341,7 @@ fn main() -> Result<()> {
         })?;
 
         // Translate environment variables from Strings to Values
-        if let Some(e) = convert_env_values(&mut engine_state, &mut stack, &config) {
+        if let Some(e) = convert_env_values(&mut engine_state, &stack, &config) {
             let working_set = StateWorkingSet::new(&engine_state);
             report_error(&working_set, &e);
         }
@@ -501,7 +501,7 @@ fn main() -> Result<()> {
 // In order to ensure the values have spans, it first creates a dummy file, writes the collected
 // env vars into it (in a "NAME"="value" format, quite similar to the output of the Unix 'env'
 // tool), then uses the file to get the spans. The file stays in memory, no filesystem IO is done.
-fn gather_parent_env_vars(engine_state: &mut EngineState, stack: &mut Stack) {
+fn gather_parent_env_vars(engine_state: &mut EngineState) {
     // Some helper functions
     fn get_surround_char(s: &str) -> Option<char> {
         if s.contains('"') {
@@ -916,7 +916,7 @@ fn eval_source(
         }
     };
 
-    let env_vars = stack.get_env_vars(&engine_state);
+    let env_vars = stack.get_env_vars(engine_state);
     stack.env_vars = vec![];
 
     if let Err(err) = engine_state.merge_delta(delta, &cwd, env_vars) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,6 @@ use nu_protocol::{
 };
 use reedline::{Completer, CompletionActionHandler, DefaultHinter, LineBuffer, Prompt, Vi};
 use std::{
-    collections::HashMap,
     io::Write,
     path::PathBuf,
     sync::{
@@ -133,7 +132,7 @@ fn main() -> Result<()> {
             (output, working_set.render())
         };
 
-        if let Err(err) = engine_state.merge_delta(delta, &init_cwd, HashMap::new()) {
+        if let Err(err) = engine_state.merge_delta(delta, None, &init_cwd) {
             let working_set = StateWorkingSet::new(&engine_state);
             report_error(&working_set, &err);
         }
@@ -210,10 +209,7 @@ fn main() -> Result<()> {
 
                 let cwd = nu_engine::env::current_dir(&engine_state, &stack)?;
 
-                let env_vars = stack.get_env_vars(&engine_state);
-                stack.env_vars = vec![];
-
-                if let Err(err) = engine_state.merge_delta(delta, &cwd, env_vars) {
+                if let Err(err) = engine_state.merge_delta(delta, Some(&mut stack), &cwd) {
                     let working_set = StateWorkingSet::new(&engine_state);
                     report_error(&working_set, &err);
                 }
@@ -919,10 +915,7 @@ fn eval_source(
         }
     };
 
-    let env_vars = stack.get_env_vars(engine_state);
-    stack.env_vars = vec![];
-
-    if let Err(err) = engine_state.merge_delta(delta, &cwd, env_vars) {
+    if let Err(err) = engine_state.merge_delta(delta, Some(stack), &cwd) {
         let working_set = StateWorkingSet::new(engine_state);
         report_error(&working_set, &err);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -207,7 +207,7 @@ fn main() -> Result<()> {
                     (output, working_set.render())
                 };
 
-                let cwd = nu_engine::env::current_dir(&engine_state, &stack)?;
+                let cwd = nu_engine::env::current_dir_str(&engine_state, &stack)?;
 
                 if let Err(err) = engine_state.merge_delta(delta, Some(&mut stack), &cwd) {
                     let working_set = StateWorkingSet::new(&engine_state);
@@ -434,7 +434,8 @@ fn main() -> Result<()> {
                 Ok(Signal::Success(s)) => {
                     let tokens = lex(s.as_bytes(), 0, &[], &[], false);
                     // Check if this is a single call to a directory, if so auto-cd
-                    let path = nu_path::expand_path(&s);
+                    let cwd = nu_engine::env::current_dir_str(&engine_state, &stack)?;
+                    let path = nu_path::expand_path_with(&s, &cwd);
                     let orig = s.clone();
 
                     if (orig.starts_with('.')
@@ -906,7 +907,7 @@ fn eval_source(
         (output, working_set.render())
     };
 
-    let cwd = match nu_engine::env::current_dir(engine_state, stack) {
+    let cwd = match nu_engine::env::current_dir_str(engine_state, stack) {
         Ok(p) => PathBuf::from(p),
         Err(e) => {
             let working_set = StateWorkingSet::new(engine_state);

--- a/src/main.rs
+++ b/src/main.rs
@@ -440,8 +440,6 @@ fn main() -> Result<()> {
                         && tokens.0.len() == 1
                     {
                         // We have an auto-cd
-                        let _ = std::env::set_current_dir(&path);
-
                         //FIXME: this only changes the current scope, but instead this environment variable
                         //should probably be a block that loads the information from the state in the overlay
                         stack.add_env_var(

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,7 +100,6 @@ fn main() -> Result<()> {
     }));
 
     // Get initial current working directory.
-    // Missing PWD error is reported later so it is not critical to report it also here.
     let init_cwd = get_init_cwd();
     let mut engine_state = create_default_context(&init_cwd);
 


### PR DESCRIPTION
The engine now uses **only** the PWD environment variable for determining the current directory. As a consequence, the PWD is now local for each scope instead of a global state (`std::env`) and thus is thread-safe. In other words, you can use `cd` in a `par-each` loop:
```
> do {
    let dirs = [
        test-pwd/d1
        test-pwd/d2
        test-pwd/d3
        test-pwd/d4
    ]

    $dirs | par-each { mkdir -s $it }
    $dirs | par-each { cd $it; touch foo.txt }

    ls test-pwd/*/*
}
# ... lists test-pwd/{d1,d2,d3,d4}/foo.txt
```

The `std::env` is updated every time we merge the delta into the engine state. This ensures parser and completions have up-to-date current directory. Writing to `std::env` during the delta merge should be safe since we don't do it in multiple threads.

## Checklist
* [ ] Fix plugins (gstat) -- need to pass them cwd
    * Partially circumvented by updating current dir in `std::env` each `merge_delta()`
    * Added a TODO note in the plugin code
* [x] Fix parser (cwd sync when merging delta)
* [x] Fix completions (cwd sync when merging delta)
* [x] Fix ls -- uses glob which uses std::env
* [x] Ensure PWD is always absolute path
    * perhaps add error about it in nu_engine::env::current_dir()
* [x] All instances of glob::glob() get absolute path
* [x] Fix performance: `benchmark { 1..100000 | each { let x = 4 } }` went from 200-300 ms to ~1s. 
* [x] Fix panic on `"/home"<tab>`
* [ ] Reedline uses `std::env::current_dir()` for default prompt (I guess that's OK)
* [x] _Seems_ like (emphasis on _seems_) we're not passing paths to any other external crates which could silently use `std::env::current_dir()`
    * I checked what commands we have and not many of them interact with paths in obvious way and those that do were fixed in this PR.\
* [x] `for` loop as well
* [x] check other looping commands for similar pattern
* [x] `im::HashMap` in engine state vs `HashMap` in the stack -- probably high cost of collecting env vars
    * Using `im::HashMap` seems to make it slightly slower.