### PR TITLE
Require let to be a statement, move auto-cd

### DIFF
--- a/crates/nu-parser/src/errors.rs
+++ b/crates/nu-parser/src/errors.rs
@@ -195,6 +195,14 @@ pub enum ParseError {
     #[diagnostic(code(nu::parser::file_not_found), url(docsrs))]
     FileNotFound(String, #[label("File not found: {0}")] Span),
 
+    #[error("'let' statements can't be part of a pipeline")]
+    #[diagnostic(
+        code(nu::parser::let_not_statement),
+        url(docsrs),
+        help("use parens to assign to a variable\neg) let x = ('hello' | str length)")
+    )]
+    LetNotStatement(#[label = "let statement part of a pipeline"] Span),
+
     #[error("{0}")]
     #[diagnostic()]
     LabeledError(String, String, #[label("{1}")] Span),

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -973,6 +973,10 @@ pub fn parse_let(
                         );
                         error = error.or(err);
 
+                        if idx < (spans.len() - 1) {
+                            error = error.or(Some(ParseError::ExtraPositional(spans[idx + 1])));
+                        }
+
                         let mut idx = 0;
                         let (lvalue, err) =
                             parse_var_with_opt_type(working_set, &spans[1..(span.0)], &mut idx);

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -3352,6 +3352,16 @@ pub fn parse_block(
                     })
                     .collect::<Vec<Expression>>();
 
+                if let Some(let_call_id) = working_set.find_decl(b"let") {
+                    for expr in output.iter() {
+                        if let Expr::Call(x) = &expr.expr {
+                            if let_call_id == x.decl_id && output.len() != 1 && error.is_none() {
+                                error = Some(ParseError::LetNotStatement(expr.span));
+                            }
+                        }
+                    }
+                }
+
                 for expr in output.iter_mut().skip(1) {
                     if expr.has_in_variable(working_set) {
                         *expr = wrap_expr_with_collect(working_set, expr);

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -113,3 +113,8 @@ fn long_flag() -> TestResult {
         "100",
     )
 }
+
+#[test]
+fn let_not_statement() -> TestResult {
+    fail_test(r#"let x = "hello" | str length"#, "can't")
+}


### PR DESCRIPTION
This PR adds the requirement that `let` is a statement rather than part of a pipeline.

We'll now give an error if you type something like:

```
let x = "hello" | str length
```

As that would visually seem to group the pipeline as part of the right-hand side, but current parsing rules mean that the pipeline gets the precedence, so this wouldn't give the user what they'd assume.

This PR also adds an error message that talks about wrapping the right-hand side in parens in the case where someone writes the above.

It also moves auto-cd to only happen in the CLI and only on a line by itself.