### PR TITLE
fix issue #559: to json -r serializes datetime without spaces

### DIFF
--- a/crates/nu-json/src/ser.rs
+++ b/crates/nu-json/src/ser.rs
@@ -4,6 +4,7 @@
 
 use std::fmt::{Display, LowerExp};
 use std::io;
+use std::io::{BufRead, BufReader};
 use std::num::FpCategory;
 
 use super::error::{Error, ErrorCode, Result};
@@ -1032,7 +1033,20 @@ where
     T: ser::Serialize,
 {
     let vec = to_vec(value)?;
-    let mut string = String::from_utf8(vec)?;
-    string.retain(|c| !c.is_whitespace());
+    let string = remove_json_whitespace(vec);
     Ok(string)
+}
+
+fn remove_json_whitespace(v: Vec<u8>) -> String {
+    let reader = BufReader::new(&v[..]);
+    let mut output = String::new();
+    for line in reader.lines() {
+        match line {
+            Ok(line) => output.push_str(line.trim().trim_end()),
+            _ => {
+                String::from("Error Removing JSON whitespace");
+            }
+        }
+    }
+    output
 }

--- a/crates/nu-json/src/ser.rs
+++ b/crates/nu-json/src/ser.rs
@@ -1044,7 +1044,7 @@ fn remove_json_whitespace(v: Vec<u8>) -> String {
         match line {
             Ok(line) => output.push_str(line.trim().trim_end()),
             _ => {
-                String::from("Error Removing JSON whitespace");
+                eprintln!("Error removing JSON whitespace");
             }
         }
     }

--- a/src/tests/test_converters.rs
+++ b/src/tests/test_converters.rs
@@ -29,3 +29,11 @@ fn to_json_raw_flag_2() -> TestResult {
         r#"[{"a b": "jim","c": "susie"},{"a b": 3,"c": 4}]"#,
     )
 }
+
+#[test]
+fn to_json_raw_flag_3() -> TestResult {
+    run_test(
+        "[[\"a b\" \"c d\"]; [\"jim smith\" \"susie roberts\"] [3 4]] | to json -r",
+        r#"[{"a b": "jim smith","c d": "susie roberts"},{"a b": 3,"c d": 4}]"#,
+    )
+}

--- a/src/tests/test_converters.rs
+++ b/src/tests/test_converters.rs
@@ -15,9 +15,17 @@ fn from_json_2() -> TestResult {
 }
 
 #[test]
-fn to_json_raw_flag() -> TestResult {
+fn to_json_raw_flag_1() -> TestResult {
     run_test(
         "[[a b]; [jim susie] [3 4]] | to json -r",
-        r#"[{"a":"jim","b":"susie"},{"a":3,"b":4}]"#,
+        r#"[{"a": "jim","b": "susie"},{"a": 3,"b": 4}]"#,
+    )
+}
+
+#[test]
+fn to_json_raw_flag_2() -> TestResult {
+    run_test(
+        "[[\"a b\" c]; [jim susie] [3 4]] | to json -r",
+        r#"[{"a b": "jim","c": "susie"},{"a b": 3,"c": 4}]"#,
     )
 }


### PR DESCRIPTION

Prior to this fix we were removing whitespace from inside the keys and values
as well as outside the keys and values....

Now we NO longer remove whitespace from inside the keys and values,
but instead are leaving them intact....

