### PR TITLE
Allow update to also insert

### DIFF
--- a/src/tests/test_table_operations.rs
+++ b/src/tests/test_table_operations.rs
@@ -192,3 +192,8 @@ fn select() -> TestResult {
         "b",
     )
 }
+
+#[test]
+fn update_will_insert() -> TestResult {
+    run_test(r#"{} | update a b | get a"#, "b")
+}


### PR DESCRIPTION
The `update` command will also now perform an insert operation for records/tables.

eg)
```
ls | update foo bar
```

Will add a new foo column, defaulting to bar as the cell value