### PR TITLE
Each needs to clone its env

### DIFF
--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -82,7 +82,8 @@ impl Command for Each {
                 .into_iter()
                 .enumerate()
                 .map(move |(idx, x)| {
-                    stack.with_env(&orig_env_vars, &orig_env_hidden);
+                    stack.env_vars = orig_env_vars.clone();
+                    stack.env_hidden = orig_env_hidden.clone();
 
                     if let Some(var) = block.signature.get_positional(0) {
                         if let Some(var_id) = &var.var_id {


### PR DESCRIPTION
Now that `PWD` is an env var, it's important that we're always seeing a fresh env each time through the loop, or we might accidentally reuse the cwd of the previous iteration.