### PR TITLE
allow sharing violation error to not fail completely

### DIFF
--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -131,9 +131,13 @@ impl Command for Ls {
                         Err(e) => {
                             if e.kind() == ErrorKind::PermissionDenied
                                 || e.kind() == ErrorKind::Other
+                            // on windows this is "The process cannot access the file
+                            // because it is being used by another process. (os error 32)"
+                            || e.raw_os_error() == Some(32)
                             {
                                 None
                             } else {
+                                eprintln!("raw {:?}", e.raw_os_error());
                                 return Some(Value::Error {
                                     error: ShellError::IOError(format!("{}", e)),
                                 });

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -137,7 +137,6 @@ impl Command for Ls {
                             {
                                 None
                             } else {
-                                eprintln!("raw {:?}", e.raw_os_error());
                                 return Some(Value::Error {
                                     error: ShellError::IOError(format!("{}", e)),
                                 });


### PR DESCRIPTION
It allows the `ls` to continue but not have much information for the files in error.
![image](https://user-images.githubusercontent.com/343840/148273408-ddaa1710-f285-4507-8e98-c969840a4ccb.png)


