### PR TITLE
Fixes how environment is cloned inside tight loops

### DIFF
--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -37,7 +37,10 @@ impl Command for Cd {
                 let path = match nu_path::canonicalize_with(path, &cwd) {
                     Ok(p) => p,
                     Err(e) => {
-                        return Err(ShellError::DirectoryNotFoundHelp(v.span()?, format!("IO Error: {:?}", e)))
+                        return Err(ShellError::DirectoryNotFoundHelp(
+                            v.span()?,
+                            format!("IO Error: {:?}", e),
+                        ))
                     }
                 };
                 (path.to_string_lossy().to_string(), v.span()?)

--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -34,11 +34,12 @@ impl Command for Cd {
         let (path, span) = match path_val {
             Some(v) => {
                 let path = v.as_path()?;
-                if !path.exists() {
-                    return Err(ShellError::DirectoryNotFound(v.span()?));
-                }
-
-                let path = nu_path::canonicalize_with(path, &cwd)?;
+                let path = match nu_path::canonicalize_with(path, &cwd) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        return Err(ShellError::DirectoryNotFoundHelp(v.span()?, format!("IO Error: {:?}", e)))
+                    }
+                };
                 (path.to_string_lossy().to_string(), v.span()?)
             }
             None => {

--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -34,7 +34,6 @@ impl Command for Cd {
         let (path, span) = match path_val {
             Some(v) => {
                 let path = v.as_path()?;
-                println!("cd: {:?}, cwd: {:?}", path, cwd);
                 let path = match nu_path::canonicalize_with(path, &cwd) {
                     Ok(p) => p,
                     Err(e) => {

--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -34,6 +34,7 @@ impl Command for Cd {
         let (path, span) = match path_val {
             Some(v) => {
                 let path = v.as_path()?;
+                println!("cd: {:?}, cwd: {:?}", path, cwd);
                 let path = match nu_path::canonicalize_with(path, &cwd) {
                     Ok(p) => p,
                     Err(e) => {

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -82,8 +82,7 @@ impl Command for Each {
                 .into_iter()
                 .enumerate()
                 .map(move |(idx, x)| {
-                    stack.env_vars = orig_env_vars.clone();
-                    stack.env_hidden = orig_env_hidden.clone();
+                    stack.with_env(&orig_env_vars, &orig_env_hidden);
 
                     if let Some(var) = block.signature.get_positional(0) {
                         if let Some(var_id) = &var.var_id {

--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -47,11 +47,12 @@ impl Stack {
     }
 
     pub fn with_env(&mut self, env_vars: &[HashMap<String, Value>], env_hidden: &HashSet<String>) {
-        if env_vars.iter().any(|scope| !scope.is_empty()) {
+        // Do not clone the environment if it hasn't changed
+        if self.env_vars.iter().any(|scope| !scope.is_empty()) {
             self.env_vars = env_vars.to_owned();
         }
 
-        if !env_hidden.is_empty() {
+        if !self.env_hidden.is_empty() {
             self.env_hidden = env_hidden.clone();
         }
     }

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -189,9 +189,13 @@ pub enum ShellError {
     #[diagnostic(code(nu::shell::directory_not_found), url(docsrs))]
     DirectoryNotFound(#[label("directory not found")] Span),
 
-    #[error("File not found")]
-    #[diagnostic(code(nu::shell::file_not_found), url(docsrs))]
+    #[error("Directory not found")]
+    #[diagnostic(code(nu::shell::directory_not_found_custom), url(docsrs))]
     DirectoryNotFoundCustom(String, #[label("{0}")] Span),
+
+    #[error("Directory not found")]
+    #[diagnostic(code(nu::shell::directory_not_found_help), url(docsrs), help("{1}"))]
+    DirectoryNotFoundHelp(#[label("directory not found")] Span, String),
 
     #[error("Move not possible")]
     #[diagnostic(code(nu::shell::move_not_possible), url(docsrs))]


### PR DESCRIPTION
The environment is cloned only if it has changed on the stack. If it hasn't changed (i.e., the stack is empty), no cloning is necessary. This prevents unnecessary cloning of the empty data structures as long as you don't modify the env vars in a tight loop.

This loop works now:
```
ls | where type == dir | each { cd $it.name; ls } | flatten
```

Also fixes how canonicalize error is displayed and a potential std::env creep in the `cd` command.