### PR TITLE
Default the values of named params

### DIFF
--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -111,14 +111,18 @@ fn eval_call(
                     }
                 }
 
-                if !found && named.arg.is_none() {
-                    callee_stack.add_var(
-                        var_id,
-                        Value::Bool {
-                            val: false,
-                            span: call.head,
-                        },
-                    )
+                if !found {
+                    if named.arg.is_none() {
+                        callee_stack.add_var(
+                            var_id,
+                            Value::Bool {
+                                val: false,
+                                span: call.head,
+                            },
+                        )
+                    } else {
+                        callee_stack.add_var(var_id, Value::Nothing { span: call.head })
+                    }
                 }
             }
         }

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -87,3 +87,35 @@ fn earlier_errors() -> TestResult {
         "int",
     )
 }
+
+#[test]
+fn missing_flags_are_nothing() -> TestResult {
+    run_test(
+        r#"def foo [--aaa(-a): int, --bbb(-b): int] { (if $aaa == $nothing { 10 } else { $aaa }) + (if $bbb == $nothing { 100 } else { $bbb }) }; foo"#,
+        "110",
+    )
+}
+
+#[test]
+fn missing_flags_are_nothing2() -> TestResult {
+    run_test(
+        r#"def foo [--aaa(-a): int, --bbb(-b): int] { (if $aaa == $nothing { 10 } else { $aaa }) + (if $bbb == $nothing { 100 } else { $bbb }) }; foo -a 90"#,
+        "190",
+    )
+}
+
+#[test]
+fn missing_flags_are_nothing3() -> TestResult {
+    run_test(
+        r#"def foo [--aaa(-a): int, --bbb(-b): int] { (if $aaa == $nothing { 10 } else { $aaa }) + (if $bbb == $nothing { 100 } else { $bbb }) }; foo -b 45"#,
+        "55",
+    )
+}
+
+#[test]
+fn missing_flags_are_nothing4() -> TestResult {
+    run_test(
+        r#"def foo [--aaa(-a): int, --bbb(-b): int] { (if $aaa == $nothing { 10 } else { $aaa }) + (if $bbb == $nothing { 100 } else { $bbb }) }; foo -a 3 -b 10000"#,
+        "10003",
+    )
+}


### PR DESCRIPTION
This allows you to check for missing named params, like so:

```
def foo [--aaa(-a): int, --bbb(-b): int] {
  (if $aaa == $nothing { 10 } else { $aaa }) + (if $bbb == $nothing { 100 } else { $bbb })
}
foo -b 45
```