### PR TITLE
add more chars

### DIFF
--- a/crates/nu-command/src/strings/char_.rs
+++ b/crates/nu-command/src/strings/char_.rs
@@ -76,6 +76,16 @@ lazy_static! {
         // Unicode can't be mixed with Ansi or it will break width calculation
         "branch" => '\u{e0a0}'.to_string(),                        // 
         "segment" => '\u{e0b0}'.to_string(),                       // 
+        "left_segment" => '\u{e0b0}'.to_string(),                  // 
+        "left_segment_thin" => '\u{e0b1}'.to_string(),             // 
+        "right_segment" => '\u{e0b2}'.to_string(),                 // 
+        "right_segment_thin" => '\u{e0b3}'.to_string(),            // 
+        "git" => '\u{f1d3}'.to_string(),                           // 
+        "git_branch" => "\u{e709}\u{e0a0}".to_string(),            // 
+        "folder1" => '\u{f07c}'.to_string(),                       // 
+        "folder2" => '\u{f115}'.to_string(),                       // 
+        "house1" => '\u{f015}'.to_string(),                        // 
+        "house2" => '\u{f7db}'.to_string(),                        // 
 
         "identical_to" => '\u{2261}'.to_string(),                  // ≡
         "hamburger" => '\u{2261}'.to_string(),                     // ≡

--- a/crates/nu-command/src/strings/char_.rs
+++ b/crates/nu-command/src/strings/char_.rs
@@ -110,23 +110,24 @@ lazy_static! {
 
         // This is the emoji section
         // Weather symbols
-        "sun" => "☀️".to_string(),
-        "sunny" => "☀️".to_string(),
-        "sunrise" => "☀️".to_string(),
-        "moon" => "🌛".to_string(),
-        "cloudy" => "☁️".to_string(),
-        "cloud" => "☁️".to_string(),
-        "clouds" => "☁️".to_string(),
-        "rainy" => "🌦️".to_string(),
-        "rain" => "🌦️".to_string(),
-        "foggy" => "🌫️".to_string(),
-        "fog" => "🌫️".to_string(),
-        "mist" => '\u{2591}'.to_string(),
-        "haze" => '\u{2591}'.to_string(),
-        "snowy" => "❄️".to_string(),
-        "snow" => "❄️".to_string(),
-        "thunderstorm" => "🌩️".to_string(),
-        "thunder" => "🌩️".to_string(),
+        // https://www.babelstone.co.uk/Unicode/whatisit.html
+        "sun" => "☀️".to_string(),         //2600 + fe0f
+        "sunny" => "☀️".to_string(),       //2600 + fe0f
+        "sunrise" => "☀️".to_string(),     //2600 + fe0f
+        "moon" => "🌛".to_string(),        //1f31b
+        "cloudy" => "☁️".to_string(),      //2601 + fe0f
+        "cloud" => "☁️".to_string(),       //2601 + fe0f
+        "clouds" => "☁️".to_string(),      //2601 + fe0f
+        "rainy" => "🌦️".to_string(),       //1f326 + fe0f
+        "rain" => "🌦️".to_string(),        //1f326 + fe0f
+        "foggy" => "🌫️".to_string(),       //1f32b + fe0f
+        "fog" => "🌫️".to_string(),         //1f32b + fe0f
+        "mist" => '\u{2591}'.to_string(),  //2591
+        "haze" => '\u{2591}'.to_string(),  //2591
+        "snowy" => "❄️".to_string(),       //2744 + fe0f
+        "snow" => "❄️".to_string(),        //2744 + fe0f
+        "thunderstorm" => "🌩️".to_string(),//1f329 + fe0f
+        "thunder" => "🌩️".to_string(),     //1f329 + fe0f
 
         // This is the "other" section
         "bel" => '\x07'.to_string(),       // Terminal Bell

--- a/crates/nu-command/src/strings/char_.rs
+++ b/crates/nu-command/src/strings/char_.rs
@@ -74,18 +74,18 @@ lazy_static! {
         // Unicode names came from https://www.compart.com/en/unicode
         // Private Use Area (U+E000-U+F8FF)
         // Unicode can't be mixed with Ansi or it will break width calculation
-        "branch" => '\u{e0a0}'.to_string(),                        // 
-        "segment" => '\u{e0b0}'.to_string(),                       // 
-        "left_segment" => '\u{e0b0}'.to_string(),                  // 
-        "left_segment_thin" => '\u{e0b1}'.to_string(),             // 
-        "right_segment" => '\u{e0b2}'.to_string(),                 // 
-        "right_segment_thin" => '\u{e0b3}'.to_string(),            // 
-        "git" => '\u{f1d3}'.to_string(),                           // 
-        "git_branch" => "\u{e709}\u{e0a0}".to_string(),            // 
-        "folder1" => '\u{f07c}'.to_string(),                       // 
-        "folder2" => '\u{f115}'.to_string(),                       // 
-        "house1" => '\u{f015}'.to_string(),                        // 
-        "house2" => '\u{f7db}'.to_string(),                        // 
+        "nf-branch" => '\u{e0a0}'.to_string(),                     // 
+        "nf-segment" => '\u{e0b0}'.to_string(),                    // 
+        "nf-left-segment" => '\u{e0b0}'.to_string(),               // 
+        "nf-left-segment-thin" => '\u{e0b1}'.to_string(),          // 
+        "nf-right-segment" => '\u{e0b2}'.to_string(),              // 
+        "nf-right-segment-thin" => '\u{e0b3}'.to_string(),         // 
+        "nf-git" => '\u{f1d3}'.to_string(),                        // 
+        "nf-git-branch" => "\u{e709}\u{e0a0}".to_string(),         // 
+        "nf-folder1" => '\u{f07c}'.to_string(),                    // 
+        "nf-folder2" => '\u{f115}'.to_string(),                    // 
+        "nf-house1" => '\u{f015}'.to_string(),                     // 
+        "nf-house2" => '\u{f7db}'.to_string(),                     // 
 
         "identical_to" => '\u{2261}'.to_string(),                  // ≡
         "hamburger" => '\u{2261}'.to_string(),                     // ≡


### PR DESCRIPTION
added a few more chars to help with prompt construction
```rust
        "nf-branch" => '\u{e0a0}'.to_string(),                     // 
        "nf-segment" => '\u{e0b0}'.to_string(),                    // 
        "nf-left-segment" => '\u{e0b0}'.to_string(),               // 
        "nf-left-segment-thin" => '\u{e0b1}'.to_string(),          // 
        "nf-right-segment" => '\u{e0b2}'.to_string(),              // 
        "nf-right-segment-thin" => '\u{e0b3}'.to_string(),         // 
        "nf-git" => '\u{f1d3}'.to_string(),                        // 
        "nf-git-branch" => "\u{e709}\u{e0a0}".to_string(),         // 
        "nf-folder1" => '\u{f07c}'.to_string(),                    // 
        "nf-folder2" => '\u{f115}'.to_string(),                    // 
        "nf-house1" => '\u{f015}'.to_string(),                     // 
        "nf-house2" => '\u{f7db}'.to_string(),                     // 
```