### PR TITLE
Fix not equal returning error when same things are compared in some cases

### DIFF
--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -280,6 +280,7 @@ pub fn math_result_type(
                 (Type::Duration, Type::Duration) => (Type::Bool, None),
                 (Type::Filesize, Type::Filesize) => (Type::Bool, None),
 
+                (x, y) if x == y => (Type::Bool, None),
                 (Type::Nothing, _) => (Type::Bool, None),
                 (_, Type::Nothing) => (Type::Bool, None),
                 (Type::Unknown, _) => (Type::Bool, None),

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -247,58 +247,8 @@ pub fn math_result_type(
                     )
                 }
             },
-            Operator::Equal => match (&lhs.ty, &rhs.ty) {
-                (Type::Float, Type::Int) => (Type::Bool, None),
-                (Type::Int, Type::Float) => (Type::Bool, None),
-                (Type::Duration, Type::Duration) => (Type::Bool, None),
-                (Type::Filesize, Type::Filesize) => (Type::Bool, None),
-
-                (x, y) if x == y => (Type::Bool, None),
-                (Type::Nothing, _) => (Type::Bool, None),
-                (_, Type::Nothing) => (Type::Bool, None),
-                (Type::Unknown, _) => (Type::Bool, None),
-                (_, Type::Unknown) => (Type::Bool, None),
-                _ => {
-                    *op = Expression::garbage(op.span);
-                    (
-                        Type::Unknown,
-                        Some(ParseError::UnsupportedOperation(
-                            op.span,
-                            lhs.span,
-                            lhs.ty.clone(),
-                            rhs.span,
-                            rhs.ty.clone(),
-                        )),
-                    )
-                }
-            },
-            Operator::NotEqual => match (&lhs.ty, &rhs.ty) {
-                (Type::Int, Type::Int) => (Type::Bool, None),
-                (Type::Float, Type::Int) => (Type::Bool, None),
-                (Type::Int, Type::Float) => (Type::Bool, None),
-                (Type::Float, Type::Float) => (Type::Bool, None),
-                (Type::Duration, Type::Duration) => (Type::Bool, None),
-                (Type::Filesize, Type::Filesize) => (Type::Bool, None),
-
-                (x, y) if x == y => (Type::Bool, None),
-                (Type::Nothing, _) => (Type::Bool, None),
-                (_, Type::Nothing) => (Type::Bool, None),
-                (Type::Unknown, _) => (Type::Bool, None),
-                (_, Type::Unknown) => (Type::Bool, None),
-                _ => {
-                    *op = Expression::garbage(op.span);
-                    (
-                        Type::Unknown,
-                        Some(ParseError::UnsupportedOperation(
-                            op.span,
-                            lhs.span,
-                            lhs.ty.clone(),
-                            rhs.span,
-                            rhs.ty.clone(),
-                        )),
-                    )
-                }
-            },
+            Operator::Equal => (Type::Bool, None),
+            Operator::NotEqual => (Type::Bool, None),
             Operator::Contains => match (&lhs.ty, &rhs.ty) {
                 (Type::String, Type::String) => (Type::Bool, None),
                 (Type::Unknown, _) => (Type::Bool, None),


### PR DESCRIPTION
## What
This PR fixes #699

## How
The equality operators now return
```rust
(Type::Bool, None),
```
so everything is allowed to be compared now. Which also fixes boolean inequality.

## Questions
While looking for this fix I found out that lots of code in operator type check is just replicated. I don't have much context but it looks like we can reduce duplication and avoid problems like being able to compare bools using `==` but not `!=`.

Also is there any reason why `Operator::Equal` doesn't have `(Type::Int, Type::Int)` and `(Type::Float, Type::Float)` patterns but `Operator::NotEqual` has them?