### PR TITLE
update Readme to final merge checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Engine-q is an experimental project to replace the core functionality in Nushell
 If you'd like to help out, come join us on the [discord](https://discord.gg/NtAbbGn) or propose some work in an issue or PR draft. We're currently looking to begin porting Nushell commands to engine-q.
 
 If you are interested in porting a command from Nushell to engine-q you are welcome to
-[comment on this issue 242](https://github.com/nushell/engine-q/issues/242) with the command name you would like to port.
+[comment on this issue 735](https://github.com/nushell/engine-q/issues/735) with the command name you would like to port.
 
 ## Giving engine-q a test drive
 


### PR DESCRIPTION

I am changing the top level engine-q Readme...

It now points to nushell/nushell#4356 instead of nushell/engine-q#242.

