### PR TITLE
Hide Windows ps status, bump reedline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.2.0"
-source = "git+https://github.com/nushell/reedline?branch=main#4c3c23c9594ab2d58015fc75beb9fd884b763614"
+source = "git+https://github.com/nushell/reedline?branch=main#c0fbcf0ed15a02861e20001c8a38023be4b2c1e6"
 dependencies = [
  "chrono",
  "crossterm",

--- a/crates/nu-command/src/system/ps.rs
+++ b/crates/nu-command/src/system/ps.rs
@@ -70,11 +70,15 @@ fn run_ps(engine_state: &EngineState, call: &Call) -> Result<PipelineData, Shell
             span,
         });
 
-        cols.push("status".to_string());
-        vals.push(Value::String {
-            val: proc.status(),
-            span,
-        });
+        #[cfg(not(windows))]
+        {
+            // Hide status on Windows until we can find a good way to support it
+            cols.push("status".to_string());
+            vals.push(Value::String {
+                val: proc.status(),
+                span,
+            });
+        }
 
         cols.push("cpu".to_string());
         vals.push(Value::Float {


### PR DESCRIPTION
Hide the `status` column for `ps` on Windows until we can come up with a good way to get it.

Also bump reedline