### PR TITLE
Save

### DIFF
--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -156,6 +156,7 @@ pub fn create_default_context(cwd: impl AsRef<Path>) -> EngineState {
             Mv,
             Open,
             Rm,
+            Save,
             Touch,
         };
 

--- a/crates/nu-command/src/filesystem/mod.rs
+++ b/crates/nu-command/src/filesystem/mod.rs
@@ -5,6 +5,7 @@ mod mkdir;
 mod mv;
 mod open;
 mod rm;
+mod save;
 mod touch;
 mod util;
 
@@ -15,4 +16,5 @@ pub use mkdir::Mkdir;
 pub use mv::Mv;
 pub use open::Open;
 pub use rm::Rm;
+pub use save::Save;
 pub use touch::Touch;

--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -1,0 +1,106 @@
+use nu_engine::CallExt;
+use nu_protocol::ast::Call;
+use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::{Category, PipelineData, ShellError, Signature, Spanned, SyntaxShape, Value};
+use std::io::Write;
+
+use std::path::Path;
+
+#[derive(Clone)]
+pub struct Save;
+
+//NOTE: this is not a real implementation :D. It's just a simple one to test with until we port the real one.
+impl Command for Save {
+    fn name(&self) -> &str {
+        "save"
+    }
+
+    fn usage(&self) -> &str {
+        "Save a file."
+    }
+
+    fn signature(&self) -> nu_protocol::Signature {
+        Signature::build("save")
+            .required("filename", SyntaxShape::Filepath, "the filename to use")
+            .switch("raw", "open file as raw binary", Some('r'))
+            .category(Category::FileSystem)
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        let raw = call.has_flag("raw");
+
+        let span = call.head;
+
+        let config = stack.get_config()?;
+
+        let path = call.req::<Spanned<String>>(engine_state, stack, 0)?;
+        let arg_span = path.span;
+        let path = Path::new(&path.item);
+
+        let mut file = match std::fs::File::create(path) {
+            Ok(file) => file,
+            Err(err) => {
+                return Ok(PipelineData::Value(
+                    Value::Error {
+                        error: ShellError::SpannedLabeledError(
+                            "Permission denied".into(),
+                            err.to_string(),
+                            arg_span,
+                        ),
+                    },
+                    None,
+                ));
+            }
+        };
+
+        let ext = if raw {
+            None
+        } else {
+            path.extension()
+                .map(|name| name.to_string_lossy().to_string())
+        };
+
+        if let Some(ext) = ext {
+            match engine_state.find_decl(format!("to {}", ext).as_bytes()) {
+                Some(converter_id) => {
+                    let output = engine_state.get_decl(converter_id).run(
+                        engine_state,
+                        stack,
+                        &Call::new(),
+                        input,
+                    )?;
+
+                    let output = output.collect_string("", &config)?;
+                    if let Err(err) = file.write_all(output.as_bytes()) {
+                        return Err(ShellError::IOError(err.to_string()));
+                    }
+
+                    Ok(PipelineData::new(span))
+                }
+                None => {
+                    let output = input.collect_string("", &config)?;
+
+                    if let Err(err) = file.write_all(output.as_bytes()) {
+                        return Err(ShellError::IOError(err.to_string()));
+                    }
+
+                    Ok(PipelineData::new(span))
+                }
+            }
+        } else {
+            let output = input.collect_string("", &config)?;
+
+            if let Err(err) = file.write_all(output.as_bytes()) {
+                return Err(ShellError::IOError(err.to_string()));
+            }
+
+            Ok(PipelineData::new(span))
+        }
+    }
+}


### PR DESCRIPTION
This adds support for `save`, which will try to convert what it's given based on the file extension (like nushell).

You can also use `--raw` to turn off file extension detection.

I did not add support for `--append` as this isn't well-defined for structured input. In theory, we should load the contents of the file and append what they give us to that structure. Currently, Nushell supports append as the file mode when writing, but this will make files with invalid formats (appending to a json file with structured data would end up with a file that's no longer valid json, for example)