### PR TITLE
fix list formatting

### DIFF
--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -283,8 +283,10 @@ fn convert_to_table(
                 vec![("string".to_string(), (row_num + row_offset).to_string())];
 
             if headers.is_empty() {
-                // if header row is empty, this is probably a list so format it that way
-                row.push(("list".to_string(), item.into_abbreviated_string(config)))
+                row.push((
+                    item.get_type().to_string(),
+                    item.into_abbreviated_string(config),
+                ))
             } else {
                 for header in headers.iter().skip(1) {
                     let result = match item {


### PR DESCRIPTION
Types like floats weren't getting formatted properly in lists. It should've been respecting the `float_precision: x` in the config.nu file.

Example: broken
```
> seq 1.0 0.1 2.0 
╭────┬────────────────────╮
│  0 │ 1                  │
│  1 │ 1.1                │
│  2 │ 1.2                │
│  3 │ 1.3                │
│  4 │ 1.4                │
│  5 │ 1.5                │
│  6 │ 1.6                │
│  7 │ 1.7000000000000002 │
│  8 │ 1.8                │
│  9 │ 1.9                │
│ 10 │ 2                  │
╰────┴────────────────────╯
```

Example: fixed, where `float_precision: 2` is set in config.nu

```
> seq 1.0 0.1 2.0 
╭────┬──────╮
│  0 │ 1.00 │
│  1 │ 1.10 │
│  2 │ 1.20 │
│  3 │ 1.30 │
│  4 │ 1.40 │
│  5 │ 1.50 │
│  6 │ 1.60 │
│  7 │ 1.70 │
│  8 │ 1.80 │
│  9 │ 1.90 │
│ 10 │ 2.00 │
╰────┴──────╯
```