### PR TITLE
allow `size` and other to count bytes from binary with `as_string()`

### DIFF
--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -172,6 +172,16 @@ impl Value {
     pub fn as_string(&self) -> Result<String, ShellError> {
         match self {
             Value::String { val, .. } => Ok(val.to_string()),
+            Value::Binary { val, .. } => Ok(match std::str::from_utf8(val) {
+                Ok(s) => s.to_string(),
+                Err(_) => {
+                    return Err(ShellError::CantConvert(
+                        "binary".into(),
+                        "string".into(),
+                        self.span()?,
+                    ))
+                }
+            }),
             x => Err(ShellError::CantConvert(
                 "string".into(),
                 x.get_type().to_string(),


### PR DESCRIPTION
This allows the `size` command, to be able to count binary bytes by converting it with `as_string()` and then counting as it does already. This may be the wrong place to do this, so I'm open to suggestions.