### PR TITLE
update all cargo crates to edition 2021

### DIFF
--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nu-cli"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 nu-engine = { path = "../nu-engine" }

--- a/crates/nu-color-config/Cargo.toml
+++ b/crates/nu-color-config/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nu-color-config"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 nu-protocol = { path = "../nu-protocol" }

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nu-command"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 build = "build.rs"
 
 

--- a/crates/nu-engine/Cargo.toml
+++ b/crates/nu-engine/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nu-engine"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 nu-protocol = { path = "../nu-protocol", features = ["plugin"] }

--- a/crates/nu-json/Cargo.toml
+++ b/crates/nu-json/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Nu Project Contributors", "Christian Zangl <laktak@cdak.net>"]
 description = "Fork of serde-hjson"
-edition = "2018"
+edition = "2021"
 license = "MIT"
 name = "nu-json"
 version = "0.37.1"

--- a/crates/nu-parser/Cargo.toml
+++ b/crates/nu-parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nu-parser"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 miette = "3.0.0"

--- a/crates/nu-path/Cargo.toml
+++ b/crates/nu-path/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Nu Project Contributors"]
 description = "Path handling library for Nushell"
-edition = "2018"
+edition = "2021"
 license = "MIT"
 name = "nu-path"
 version = "0.37.1"
@@ -9,4 +9,3 @@ version = "0.37.1"
 [dependencies]
 dirs-next = "2.0.0"
 dunce = "1.0.1"
-

--- a/crates/nu-plugin/Cargo.toml
+++ b/crates/nu-plugin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nu-plugin"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 capnp = "0.14.3"
@@ -9,6 +9,3 @@ nu-protocol = { path = "../nu-protocol" }
 nu-engine = { path = "../nu-engine" }
 serde = {version = "1.0.130", features = ["derive"]}
 serde_json = { version = "1.0"}
-
-
-

--- a/crates/nu-pretty-hex/Cargo.toml
+++ b/crates/nu-pretty-hex/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Andrei Volnin <wolandr@gmail.com>", "The Nu Project Contributors"]
 description = "Pretty hex dump of bytes slice in the common style."
-edition = "2018"
+edition = "2021"
 license = "MIT"
 name = "nu-pretty-hex"
 version = "0.41.0"

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nu-protocol"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/nu-table/Cargo.toml
+++ b/crates/nu-table/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Nu Project Contributors"]
 description = "Nushell table printing"
-edition = "2018"
+edition = "2021"
 license = "MIT"
 name = "nu-table"
 version = "0.36.0"

--- a/crates/nu-term-grid/Cargo.toml
+++ b/crates/nu-term-grid/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Nu Project Contributors"]
 description = "Nushell grid printing"
-edition = "2018"
+edition = "2021"
 license = "MIT"
 name = "nu-term-grid"
 version = "0.36.0"

--- a/crates/nu_plugin_example/Cargo.toml
+++ b/crates/nu_plugin_example/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Nu Project Contributors"]
 description = "A version incrementer plugin for Nushell"
-edition = "2018"
+edition = "2021"
 license = "MIT"
 name = "nu_plugin_example"
 version = "0.1.0"

--- a/crates/nu_plugin_gstat/Cargo.toml
+++ b/crates/nu_plugin_gstat/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Nu Project Contributors"]
 description = "A git status plugin for Nushell"
-edition = "2018"
+edition = "2021"
 license = "MIT"
 name = "nu_plugin_gstat"
 version = "0.1.0"

--- a/crates/nu_plugin_inc/Cargo.toml
+++ b/crates/nu_plugin_inc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Nu Project Contributors"]
 description = "A version incrementer plugin for Nushell"
-edition = "2018"
+edition = "2021"
 license = "MIT"
 name = "nu_plugin_inc"
 version = "0.1.0"


### PR DESCRIPTION

it looks like on my local machine that the 2021 edition for all cargo crates is working....