### PR TITLE
`PATH` for completions for each os

### DIFF
--- a/crates/nu-cli/src/completions.rs
+++ b/crates/nu-cli/src/completions.rs
@@ -23,16 +23,7 @@ impl NuCompleter {
         let mut executables = vec![];
 
         let paths;
-
-        #[cfg(windows)]
-        {
-            paths = self.engine_state.env_vars.get("Path");
-        }
-
-        #[cfg(not(windows))]
-        {
-            paths = self.engine_state.env_vars.get("PATH");
-        }
+        paths = self.engine_state.env_vars.get("PATH");
 
         if let Some(paths) = paths {
             if let Ok(paths) = paths.as_list() {


### PR DESCRIPTION
we used to have to check `Path` on Windows and `PATH` on linux/mac. It appears that we now can just check `PATH`, yay!