### PR TITLE
Support recursive functions in capture

### DIFF
--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -155,7 +155,8 @@ pub fn parse_for(
         // will come into scope as params. Because of this, we need to recalculated what
         // variables this block will capture from the outside.
         let mut seen = vec![];
-        let captures = find_captures_in_block(working_set, block, &mut seen);
+        let mut seen_decls = vec![];
+        let captures = find_captures_in_block(working_set, block, &mut seen, &mut seen_decls);
 
         let mut block = working_set.get_block_mut(block_id);
         block.captures = captures;
@@ -271,7 +272,8 @@ pub fn parse_def(
             // will come into scope as params. Because of this, we need to recalculated what
             // variables this block will capture from the outside.
             let mut seen = vec![];
-            let captures = find_captures_in_block(working_set, block, &mut seen);
+            let mut seen_decls = vec![];
+            let captures = find_captures_in_block(working_set, block, &mut seen, &mut seen_decls);
 
             let mut block = working_set.get_block_mut(block_id);
             block.captures = captures;

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -164,3 +164,8 @@ fn string_interp_with_equals() -> TestResult {
         "https://api.github.com/search/issues?q=repo:nushell/",
     )
 }
+
+#[test]
+fn recursive_parse() -> TestResult {
+    run_test(r#"def c [] { c }; echo done"#, "done")
+}


### PR DESCRIPTION
This fixes an issue when doing variable captures, where we'd capture recursively if functions were recursive (or mutually recursive). This avoids recalculating functions already in-progress to be calculated.

fixes #795 

