### PR TITLE
lint: remove trailing whitespace

### DIFF
--- a/crates/nu-command/src/network/fetch.rs
+++ b/crates/nu-command/src/network/fetch.rs
@@ -45,7 +45,7 @@ impl Command for SubCommand {
                 Some('p'),
             )
             .named("timeout", SyntaxShape::Int, "timeout period in seconds", Some('t'))
-            .switch("raw", "fetch contents as text rather than a table", Some('r'))            
+            .switch("raw", "fetch contents as text rather than a table", Some('r'))
             .filter()
             .category(Category::Network)
     }


### PR DESCRIPTION
I am surprised the CI `cargo fmt --all -- --check` did not catch this.