### PR TITLE
Fix doc comments for custom commands

### DIFF
--- a/crates/nu-parser/tests/test_lite_parser.rs
+++ b/crates/nu-parser/tests/test_lite_parser.rs
@@ -97,16 +97,11 @@ fn separated_comments_dont_stack() -> Result<(), ParseError> {
     let lite_block = lite_parse_helper(input)?;
 
     assert_eq!(lite_block.block.len(), 1);
-    assert_eq!(lite_block.block[0].commands[0].comments.len(), 2);
+    assert_eq!(lite_block.block[0].commands[0].comments.len(), 1);
     assert_eq!(lite_block.block[0].commands[0].parts.len(), 3);
 
     assert_eq!(
         lite_block.block[0].commands[0].comments[0],
-        Span { start: 0, end: 19 }
-    );
-
-    assert_eq!(
-        lite_block.block[0].commands[0].comments[1],
         Span { start: 21, end: 38 }
     );
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -47,6 +47,31 @@ pub fn run_test(input: &str, expected: &str) -> TestResult {
 }
 
 #[cfg(test)]
+pub fn run_test_contains(input: &str, expected: &str) -> TestResult {
+    let mut file = NamedTempFile::new()?;
+    let name = file.path();
+
+    let mut cmd = Command::cargo_bin("engine-q")?;
+    cmd.arg(name);
+
+    writeln!(file, "{}", input)?;
+
+    let output = cmd.output()?;
+
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+
+    println!("stdout: {}", stdout);
+    println!("stderr: {}", stderr);
+
+    assert!(output.status.success());
+
+    assert!(stdout.contains(expected));
+
+    Ok(())
+}
+
+#[cfg(test)]
 pub fn fail_test(input: &str, expected: &str) -> TestResult {
     let mut file = NamedTempFile::new()?;
     let name = file.path();

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -1,5 +1,7 @@
 use crate::tests::{fail_test, run_test, TestResult};
 
+use super::run_test_contains;
+
 #[test]
 fn env_shorthand() -> TestResult {
     run_test("FOO=BAR if $false { 3 } else { 4 }", "4")
@@ -168,4 +170,17 @@ fn string_interp_with_equals() -> TestResult {
 #[test]
 fn recursive_parse() -> TestResult {
     run_test(r#"def c [] { c }; echo done"#, "done")
+}
+
+#[test]
+fn commands_have_usage() -> TestResult {
+    run_test_contains(
+        r#"
+    # This is a test
+    #
+    # To see if I have cool usage
+    def foo [] {}
+    help foo"#,
+        "cool usage",
+    )
 }


### PR DESCRIPTION
This allows you to put doc comments onto custom commands, like:

```
# This is a custom command I made
#
# I'm very proud of it
def hello-world [] { echo "I say hello here" }
```