### PR TITLE
draft: Bump `ansi-cut` version to 0.2.0

### DIFF
--- a/crates/nu-table/Cargo.toml
+++ b/crates/nu-table/Cargo.toml
@@ -18,5 +18,5 @@ nu-protocol = { path = "../nu-protocol"}
 regex = "1.4"
 unicode-width = "0.1.8"
 strip-ansi-escapes = "0.1.1"
-ansi-cut = "0.1.1"
+ansi-cut = "0.2.0"
 atty = "0.2.14"

--- a/crates/nu-table/src/wrap.rs
+++ b/crates/nu-table/src/wrap.rs
@@ -152,7 +152,7 @@ fn split_word(cell_width: usize, word: &str) -> Vec<Subline> {
     let mut end_index;
 
     let word_no_ansi = strip_ansi(word);
-    for c in word_no_ansi.chars().enumerate() {
+    for c in word_no_ansi.char_indices() {
         if let Some(width) = c.1.width() {
             end_index = c.0;
             if current_width + width > cell_width {
@@ -169,7 +169,7 @@ fn split_word(cell_width: usize, word: &str) -> Vec<Subline> {
         }
     }
 
-    if start_index != word_no_ansi.chars().count() {
+    if start_index != word_no_ansi.len() {
         output.push(Subline {
             subline: word.cut(start_index..),
             width: current_width,


### PR DESCRIPTION
Hi there,

After overseeing #767.
I noticed an issue in `ansi-cut`.

If color was used like this `"\u{1b}[41m\u{1b}[30msomething\u{1b}[39m \u{1b}[34m123123\u{1b}[39m\u{1b}[49m"`
(A color was closed not each time it is used) we did not recognize that, therefore the colors could be screwed.

I did a fix so it must be handled right now.

And I am here point out about the issue and to bring the fix.

But doing the bump.
I did not found any tests.
Do you have any?

As it's not quite safe to make just a bump because now `ansi-cut` `panic`s when you index not a UTF-8 code point boundary (it uses byte indexing now as well)

____

I did not inspect deliberately these lines, just have a little concern that `word.cut(start_index..end_index+width)` must be used here?

https://github.com/nushell/engine-q/blob/310ecb79b670f04aaf52b6366a6fce2c130a5c75/crates/nu-table/src/wrap.rs#L155-L160

Thank you