### PR TITLE
capture keyboard event

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,12 +64,11 @@ dependencies = [
 
 [[package]]
 name = "ansi-cut"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "116f67a17a90942bc30b3fe78b800941f8276234386844b3e0dee3f9d2782839"
+checksum = "ffe8d2994390ae20a3eb52a909f9518a89f8fd7e6990f3d25d38e51021b2c8ce"
 dependencies = [
  "ansi-parser",
- "strip-ansi-escapes",
 ]
 
 [[package]]

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -174,6 +174,7 @@ pub fn create_default_context(cwd: impl AsRef<Path>) -> EngineState {
             AnsiStrip,
             Clear,
             Input,
+            InputKeys,
             Kill,
             Sleep,
             TermSize,

--- a/crates/nu-command/src/platform/input_keys.rs
+++ b/crates/nu-command/src/platform/input_keys.rs
@@ -1,5 +1,5 @@
-use core::time::Duration;
-use crossterm::{event::poll, event::Event, event::KeyCode, event::KeyEvent, terminal};
+use crossterm::QueueableCommand;
+use crossterm::{event::Event, event::KeyCode, event::KeyEvent, terminal};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
@@ -26,34 +26,64 @@ impl Command for InputKeys {
     fn run(
         &self,
         _engine_state: &EngineState,
-        _stack: &mut Stack,
+        stack: &mut Stack,
         _call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        // println!("Ready to print events (Abort with ESC):");
-        println!("You have 5 seconds to hit a key combination:");
-        Ok(print_events()?.into_pipeline_data())
+        println!("Type any key combination to see key details. Press ESC to abort.");
+
+        match print_events(stack) {
+            Ok(v) => Ok(v.into_pipeline_data()),
+            Err(e) => {
+                terminal::disable_raw_mode()?;
+                Err(ShellError::LabeledError(
+                    "Error with input".to_string(),
+                    e.to_string(),
+                ))
+            }
+        }
     }
 
     fn examples(&self) -> Vec<Example> {
         vec![Example {
-            description: "Get one key event",
+            description: "Type and see key event codes",
             example: "input-keys",
             result: None,
         }]
     }
 }
 
-pub fn print_events() -> Result<Value, ShellError> {
+pub fn print_events(stack: &mut Stack) -> Result<Value, ShellError> {
+    let config = stack.get_config()?;
+
     stdout().flush()?;
     terminal::enable_raw_mode()?;
+    let mut stdout = std::io::BufWriter::new(std::io::stderr());
+
     loop {
         let event = crossterm::event::read()?;
         if event == Event::Key(KeyCode::Esc.into()) {
             break;
         }
+        // stdout.queue(crossterm::style::Print(format!("event: {:?}", &event)))?;
+        // stdout.queue(crossterm::style::Print("\r\n"))?;
 
-        print_events_helper(event)?;
+        // Get a record
+        let v = print_events_helper(event)?;
+        // Print out the record
+        let o = match v {
+            Value::Record { cols, vals, .. } => cols
+                .iter()
+                .zip(vals.iter())
+                .map(|(x, y)| format!("{}: {}", x, y.into_string("", &config)))
+                .collect::<Vec<String>>()
+                .join(", "),
+
+            _ => "".to_string(),
+        };
+        stdout.queue(crossterm::style::Print(o))?;
+        stdout.queue(crossterm::style::Print("\r\n"))?;
+        stdout.flush()?;
     }
     terminal::disable_raw_mode()?;
 
@@ -66,69 +96,47 @@ pub fn print_events() -> Result<Value, ShellError> {
 // are printed, it's a good chance your terminal is eating
 // those events.
 fn print_events_helper(event: Event) -> Result<Value, ShellError> {
-    // loop {
-    // Wait up to 5s for another event
-    if poll(Duration::from_millis(5_000))? {
-        // It's guaranteed that read() wont block if `poll` returns `Ok(true)`
-        // let event = crossterm::event::read()?;
-
-        if let Event::Key(KeyEvent { code, modifiers }) = event {
-            match code {
-                KeyCode::Char(c) => {
-                    let record = Value::Record {
-                        cols: vec![
-                            "char".into(),
-                            "code".into(),
-                            "modifier".into(),
-                            "flags".into(),
-                        ],
-                        vals: vec![
-                            Value::string(format!("{}", c), Span::test_data()),
-                            Value::string(format!("{:#08x}", u32::from(c)), Span::test_data()),
-                            Value::string(format!("{:?}", modifiers), Span::test_data()),
-                            Value::string(format!("{:#08b}", modifiers), Span::test_data()),
-                        ],
-                        span: Span::test_data(),
-                    };
-                    return Ok(record);
-                }
-                _ => {
-                    let record = Value::Record {
-                        cols: vec!["code".into(), "modifier".into(), "flags".into()],
-                        vals: vec![
-                            Value::string(format!("{:?}", code), Span::test_data()),
-                            Value::string(format!("{:?}", modifiers), Span::test_data()),
-                            Value::string(format!("{:#08b}", modifiers), Span::test_data()),
-                        ],
-                        span: Span::test_data(),
-                    };
-                    return Ok(record);
-                }
+    if let Event::Key(KeyEvent { code, modifiers }) = event {
+        match code {
+            KeyCode::Char(c) => {
+                let record = Value::Record {
+                    cols: vec![
+                        "char".into(),
+                        "code".into(),
+                        "modifier".into(),
+                        "flags".into(),
+                    ],
+                    vals: vec![
+                        Value::string(format!("{}", c), Span::test_data()),
+                        Value::string(format!("{:#08x}", u32::from(c)), Span::test_data()),
+                        Value::string(format!("{:?}", modifiers), Span::test_data()),
+                        Value::string(format!("{:#08b}", modifiers), Span::test_data()),
+                    ],
+                    span: Span::test_data(),
+                };
+                Ok(record)
             }
-        } else {
-            let record = Value::Record {
-                cols: vec!["event".into()],
-                vals: vec![Value::string(format!("{:?}", event), Span::test_data())],
-                span: Span::test_data(),
-            };
-            return Ok(record);
+            _ => {
+                let record = Value::Record {
+                    cols: vec!["code".into(), "modifier".into(), "flags".into()],
+                    vals: vec![
+                        Value::string(format!("{:?}", code), Span::test_data()),
+                        Value::string(format!("{:?}", modifiers), Span::test_data()),
+                        Value::string(format!("{:#08b}", modifiers), Span::test_data()),
+                    ],
+                    span: Span::test_data(),
+                };
+                Ok(record)
+            }
         }
-
-        // hit the esc key to git out
-        // if event == Event::Key(KeyCode::Esc.into()) {
-        //     break;
-        // }
     } else {
-        // Timeout expired, no event for 5s
-        return Ok(Value::string(
-            "Waiting for you to type...".to_string(),
-            Span::test_data(),
-        ));
+        let record = Value::Record {
+            cols: vec!["event".into()],
+            vals: vec![Value::string(format!("{:?}", event), Span::test_data())],
+            span: Span::test_data(),
+        };
+        Ok(record)
     }
-    // }
-
-    // Ok(())
-    // Ok(Value::nothing(Span::test_data()))
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/platform/input_keys.rs
+++ b/crates/nu-command/src/platform/input_keys.rs
@@ -1,0 +1,136 @@
+use core::time::Duration;
+use crossterm::{event::poll, event::Event, event::KeyCode, event::KeyEvent, terminal};
+use nu_protocol::ast::Call;
+use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::{
+    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Span, Value,
+};
+use std::io::{stdout, Write};
+
+#[derive(Clone)]
+pub struct InputKeys;
+
+impl Command for InputKeys {
+    fn name(&self) -> &str {
+        "input-keys"
+    }
+
+    fn usage(&self) -> &str {
+        "Get input from the user."
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("input-keys").category(Category::Platform)
+    }
+
+    fn run(
+        &self,
+        _engine_state: &EngineState,
+        _stack: &mut Stack,
+        _call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        // println!("Ready to print events (Abort with ESC):");
+        println!("You have 5 seconds to hit a key combination:");
+        Ok(print_events()?.into_pipeline_data())
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Get one key event",
+            example: "input-keys",
+            result: None,
+        }]
+    }
+}
+
+pub fn print_events() -> Result<Value, ShellError> {
+    stdout().flush()?;
+    terminal::enable_raw_mode()?;
+    let result = print_events_helper();
+    terminal::disable_raw_mode()?;
+
+    result
+}
+
+// this fn is totally ripped off from crossterm's examples
+// it's really a diagnostic routine to see if crossterm is
+// even seeing the events. if you press a key and no events
+// are printed, it's a good chance your terminal is eating
+// those events.
+fn print_events_helper() -> Result<Value, ShellError> {
+    loop {
+        // Wait up to 5s for another event
+        if poll(Duration::from_millis(5_000))? {
+            // It's guaranteed that read() wont block if `poll` returns `Ok(true)`
+            let event = crossterm::event::read()?;
+
+            if let Event::Key(KeyEvent { code, modifiers }) = event {
+                match code {
+                    KeyCode::Char(c) => {
+                        let record = Value::Record {
+                            cols: vec![
+                                "char".into(),
+                                "code".into(),
+                                "modifier".into(),
+                                "flags".into(),
+                            ],
+                            vals: vec![
+                                Value::string(format!("{}", c), Span::test_data()),
+                                Value::string(format!("{:#08x}", u32::from(c)), Span::test_data()),
+                                Value::string(format!("{:?}", modifiers), Span::test_data()),
+                                Value::string(format!("{:#08b}", modifiers), Span::test_data()),
+                            ],
+                            span: Span::test_data(),
+                        };
+                        return Ok(record);
+                    }
+                    _ => {
+                        let record = Value::Record {
+                            cols: vec!["code".into(), "modifier".into(), "flags".into()],
+                            vals: vec![
+                                Value::string(format!("{:?}", code), Span::test_data()),
+                                Value::string(format!("{:?}", modifiers), Span::test_data()),
+                                Value::string(format!("{:#08b}", modifiers), Span::test_data()),
+                            ],
+                            span: Span::test_data(),
+                        };
+                        return Ok(record);
+                    }
+                }
+            } else {
+                let record = Value::Record {
+                    cols: vec!["event".into()],
+                    vals: vec![Value::string(format!("{:?}", event), Span::test_data())],
+                    span: Span::test_data(),
+                };
+                return Ok(record);
+            }
+
+            // hit the esc key to git out
+            // if event == Event::Key(KeyCode::Esc.into()) {
+            //     break;
+            // }
+        } else {
+            // Timeout expired, no event for 5s
+            return Ok(Value::string(
+                "Waiting for you to type...".to_string(),
+                Span::test_data(),
+            ));
+        }
+    }
+
+    // Ok(())
+    // Ok(Value::nothing(Span::test_data()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::InputKeys;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::test_examples;
+        test_examples(InputKeys {})
+    }
+}

--- a/crates/nu-command/src/platform/mod.rs
+++ b/crates/nu-command/src/platform/mod.rs
@@ -1,6 +1,7 @@
 mod ansi;
 mod clear;
 mod input;
+mod input_keys;
 mod kill;
 mod sleep;
 mod term_size;
@@ -8,6 +9,7 @@ mod term_size;
 pub use ansi::{Ansi, AnsiGradient, AnsiStrip};
 pub use clear::Clear;
 pub use input::Input;
+pub use input_keys::InputKeys;
 pub use kill::Kill;
 pub use sleep::Sleep;
 pub use term_size::TermSize;


### PR DESCRIPTION
<kbd>option</kbd> + <kbd>delete</kbd>
<img width="434" alt="Screen Shot 2022-01-23 at 7 31 47 AM" src="https://user-images.githubusercontent.com/343840/150680928-8591f785-5c06-4231-b7d6-a38b6a669fbb.png">
<kbd>control</kbd> + <kdb>d</kbd>
<img width="437" alt="Screen Shot 2022-01-23 at 7 34 05 AM" src="https://user-images.githubusercontent.com/343840/150681004-5f4b8826-5760-4573-8df7-b78e1184c7f1.png">

I can only capture one key event. Do you think we can make this loop somehow?
/cc @jntrnr 

Update: couldn't get nushell tables to work but got a raw mode to work.
<img width="618" alt="Screen Shot 2022-01-23 at 3 47 49 PM" src="https://user-images.githubusercontent.com/343840/150699183-ff584949-e54a-4efc-888b-6d8a8de6d137.png">
