### PR TITLE
fix several cases where sort-by was crashing engine-q

### DIFF
--- a/crates/nu-engine/src/column.rs
+++ b/crates/nu-engine/src/column.rs
@@ -1,4 +1,5 @@
 use nu_protocol::Value;
+use std::collections::HashSet;
 
 pub fn get_columns(input: &[Value]) -> Vec<String> {
     let mut columns = vec![];
@@ -14,4 +15,24 @@ pub fn get_columns(input: &[Value]) -> Vec<String> {
     }
 
     columns
+}
+
+/*
+*  Check to see if any of the columns inside the input
+*  does not exist in a vec of columns
+*/
+
+pub fn column_does_not_exist(inputs: Vec<String>, columns: Vec<String>) -> bool {
+    let mut set = HashSet::new();
+    for column in columns {
+        set.insert(column);
+    }
+
+    for input in &inputs {
+        if set.contains(input) {
+            continue;
+        }
+        return true;
+    }
+    false
 }


### PR DESCRIPTION

**_sort-by_** is crashing engine-q under certain input sequences...
this hopefully fixes everything except for the case of types.
that will be addressed next after this lands.

this PR fixes the following cases

* ls | sort-by
* ls | sort-by unknown-column
* ls | sort-by unknown-column known-column
* ls | sort-by known-column unknown-column
