### PR TITLE
Fix bug in date comparison

### DIFF
--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -859,9 +859,7 @@ impl PartialOrd for Value {
             (Value::Float { val: lhs, .. }, Value::Float { val: rhs, .. }) => {
                 compare_floats(*lhs, *rhs)
             }
-            (Value::Date { val: lhs, .. }, Value::Date { val: rhs, .. }) => {
-                lhs.date().to_string().partial_cmp(&rhs.date().to_string())
-            }
+            (Value::Date { val: lhs, .. }, Value::Date { val: rhs, .. }) => lhs.partial_cmp(rhs),
             (Value::String { val: lhs, .. }, Value::String { val: rhs, .. }) => {
                 lhs.partial_cmp(rhs)
             }

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -161,3 +161,8 @@ fn divide_duration() -> TestResult {
 fn divide_filesize() -> TestResult {
     run_test(r#"4mb / 4mb"#, "1")
 }
+
+#[test]
+fn date_comparison() -> TestResult {
+    run_test(r#"(date now) < ((date now) + 2min)"#, "true")
+}


### PR DESCRIPTION
# Description

Fixes a bug in date comparison where we were comparison for a new day rather than any change to the datetime.
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
