### PR TITLE
Flatten records

### DIFF
--- a/crates/nu-command/src/filters/flatten.rs
+++ b/crates/nu-command/src/filters/flatten.rs
@@ -166,10 +166,18 @@ fn flat_value(columns: &[CellPath], item: &Value, _name_tag: Span) -> Vec<Value>
                 }
                 pairs
             };
+
             for (column, value) in records_iterator {
                 let column_requested = columns.iter().find(|c| c.into_string() == *column);
 
                 match value {
+                    Value::Record {
+                        cols,
+                        vals,
+                        span: _,
+                    } => cols.iter().enumerate().for_each(|(idx, column)| {
+                        out.insert(column.to_string(), vals[idx].clone());
+                    }),
                     Value::List { vals, span: _ } if vals.iter().all(|f| f.as_record().is_ok()) => {
                         let mut cs = vec![];
                         let mut vs = vec![];


### PR DESCRIPTION
# Description

Flatten records when calling `flatten`. Closes #828
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
