### PR TITLE
Fix expanding external args

### DIFF
--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -302,9 +302,16 @@ impl<'call> ExternalCommand<'call> {
         let mut process = std::process::Command::new(&new_head);
 
         for arg in self.args.iter() {
-            let arg = Spanned {
+            let mut arg = Spanned {
                 item: trim_enclosing_quotes(&arg.item),
                 span: arg.span,
+            };
+            arg.item = if arg.item.starts_with('~') || arg.item.starts_with("..") {
+                nu_path::expand_path_with(&arg.item, cwd)
+                    .to_string_lossy()
+                    .to_string()
+            } else {
+                arg.item
             };
 
             let cwd = PathBuf::from(cwd);


### PR DESCRIPTION
# Description

Fixes #844. Recent support for globs accidentally removed path expansion on external args. This should add back what we had previously.
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
