### PR TITLE
Add -c flag and others to cmdline args

### DIFF
--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -267,7 +267,7 @@ fn get_flags_section(signature: &Signature) -> String {
             if let Some(short) = flag.short {
                 if flag.required {
                     format!(
-                        "  -{}{} (required parameter) {:?} {}\n",
+                        "  -{}{} (required parameter) {:?}\n      {}\n",
                         short,
                         if !flag.long.is_empty() {
                             format!(", --{}", flag.long)
@@ -279,7 +279,7 @@ fn get_flags_section(signature: &Signature) -> String {
                     )
                 } else {
                     format!(
-                        "  -{}{} {:?} {}\n",
+                        "  -{}{} <{:?}>\n      {}\n",
                         short,
                         if !flag.long.is_empty() {
                             format!(", --{}", flag.long)
@@ -292,16 +292,16 @@ fn get_flags_section(signature: &Signature) -> String {
                 }
             } else if flag.required {
                 format!(
-                    "  --{} (required parameter) {:?} {}\n",
+                    "  --{} (required parameter) <{:?}>\n      {}\n",
                     flag.long, arg, flag.desc
                 )
             } else {
-                format!("  --{} {:?} {}\n", flag.long, arg, flag.desc)
+                format!("  --{} {:?}\n      {}\n", flag.long, arg, flag.desc)
             }
         } else if let Some(short) = flag.short {
             if flag.required {
                 format!(
-                    "  -{}{} (required parameter) {}\n",
+                    "  -{}{} (required parameter)\n      {}\n",
                     short,
                     if !flag.long.is_empty() {
                         format!(", --{}", flag.long)
@@ -312,7 +312,7 @@ fn get_flags_section(signature: &Signature) -> String {
                 )
             } else {
                 format!(
-                    "  -{}{} {}\n",
+                    "  -{}{}\n      {}\n",
                     short,
                     if !flag.long.is_empty() {
                         format!(", --{}", flag.long)
@@ -323,9 +323,12 @@ fn get_flags_section(signature: &Signature) -> String {
                 )
             }
         } else if flag.required {
-            format!("  --{} (required parameter) {}\n", flag.long, flag.desc)
+            format!(
+                "  --{} (required parameter)\n      {}\n",
+                flag.long, flag.desc
+            )
         } else {
-            format!("  --{} {}\n", flag.long, flag.desc)
+            format!("  --{}\n      {}\n", flag.long, flag.desc)
         };
         long_desc.push_str(&msg);
     }

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -206,7 +206,10 @@ pub fn get_documentation(
         }
 
         if let Some(rest_positional) = &sig.rest_positional {
-            long_desc.push_str(&format!("  ...args: {}\n", rest_positional.desc));
+            long_desc.push_str(&format!(
+                "  ...{}: {}\n",
+                rest_positional.name, rest_positional.desc
+            ));
         }
     }
 

--- a/crates/nu-parser/src/lib.rs
+++ b/crates/nu-parser/src/lib.rs
@@ -13,7 +13,7 @@ pub use flatten::{
 pub use lex::{lex, Token, TokenContents};
 pub use lite_parse::{lite_parse, LiteBlock};
 
-pub use parser::{find_captures_in_expr, parse, trim_quotes, Import};
+pub use parser::{find_captures_in_expr, parse, parse_block, trim_quotes, Import};
 
 #[cfg(feature = "plugin")]
 pub use parse_keywords::parse_register;

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,0 +1,136 @@
+use miette::Result;
+use nu_engine::{convert_env_values, eval_block};
+use std::path::Path;
+
+use nu_parser::{lex, lite_parse, parse_block, trim_quotes};
+use nu_protocol::{
+    engine::{EngineState, StateDelta, StateWorkingSet},
+    Config, PipelineData, Span, Spanned, Value, CONFIG_VARIABLE_ID,
+};
+
+use crate::utils::{gather_parent_env_vars, report_error};
+
+pub(crate) fn evaluate(
+    commands: &Spanned<String>,
+    init_cwd: &Path,
+    engine_state: &mut EngineState,
+    input: PipelineData,
+) -> Result<()> {
+    // First, set up env vars as strings only
+    gather_parent_env_vars(engine_state);
+
+    // Run a command (or commands) given to us by the user
+    let (block, delta) = {
+        let mut working_set = StateWorkingSet::new(engine_state);
+
+        let (input, span_offset) =
+            if commands.item.starts_with('\'') || commands.item.starts_with('"') {
+                (
+                    trim_quotes(commands.item.as_bytes()),
+                    commands.span.start + 1,
+                )
+            } else {
+                (commands.item.as_bytes(), commands.span.start)
+            };
+
+        let (output, err) = lex(input, span_offset, &[], &[], false);
+        if let Some(err) = err {
+            report_error(&working_set, &err);
+
+            std::process::exit(1);
+        }
+
+        let (output, err) = lite_parse(&output);
+        if let Some(err) = err {
+            report_error(&working_set, &err);
+
+            std::process::exit(1);
+        }
+
+        let (output, err) = parse_block(&mut working_set, &output, false);
+        if let Some(err) = err {
+            report_error(&working_set, &err);
+
+            std::process::exit(1);
+        }
+
+        if let Some(err) = err {
+            report_error(&working_set, &err);
+
+            std::process::exit(1);
+        }
+        (output, working_set.render())
+    };
+
+    if let Err(err) = engine_state.merge_delta(delta, None, init_cwd) {
+        let working_set = StateWorkingSet::new(engine_state);
+        report_error(&working_set, &err);
+    }
+
+    let mut stack = nu_protocol::engine::Stack::new();
+
+    // Set up our initial config to start from
+    stack.vars.insert(
+        CONFIG_VARIABLE_ID,
+        Value::Record {
+            cols: vec![],
+            vals: vec![],
+            span: Span { start: 0, end: 0 },
+        },
+    );
+
+    let config = match stack.get_config() {
+        Ok(config) => config,
+        Err(e) => {
+            let working_set = StateWorkingSet::new(engine_state);
+
+            report_error(&working_set, &e);
+            Config::default()
+        }
+    };
+
+    // Merge the delta in case env vars changed in the config
+    match nu_engine::env::current_dir(engine_state, &stack) {
+        Ok(cwd) => {
+            if let Err(e) = engine_state.merge_delta(StateDelta::new(), Some(&mut stack), cwd) {
+                let working_set = StateWorkingSet::new(engine_state);
+                report_error(&working_set, &e);
+            }
+        }
+        Err(e) => {
+            let working_set = StateWorkingSet::new(engine_state);
+            report_error(&working_set, &e);
+        }
+    }
+
+    // Translate environment variables from Strings to Values
+    if let Some(e) = convert_env_values(engine_state, &stack, &config) {
+        let working_set = StateWorkingSet::new(engine_state);
+        report_error(&working_set, &e);
+        std::process::exit(1);
+    }
+
+    match eval_block(engine_state, &mut stack, &block, input) {
+        Ok(pipeline_data) => {
+            for item in pipeline_data {
+                if let Value::Error { error } = item {
+                    let working_set = StateWorkingSet::new(engine_state);
+
+                    report_error(&working_set, &error);
+
+                    std::process::exit(1);
+                }
+                println!("{}", item.into_string("\n", &config));
+            }
+        }
+        Err(err) => {
+            let working_set = StateWorkingSet::new(engine_state);
+
+            report_error(&working_set, &err);
+
+            std::process::exit(1);
+        }
+    }
+
+    Ok(())
+}

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -1,10 +1,4 @@
-use std::{
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
-    time::Instant,
-};
+use std::{sync::atomic::Ordering, time::Instant};
 
 use crate::{config_files, prompt_update, reedline_config};
 use crate::{
@@ -23,7 +17,7 @@ use nu_protocol::{
 };
 use reedline::{DefaultHinter, Emacs, Vi};
 
-pub(crate) fn evaluate(ctrlc: Arc<AtomicBool>, engine_state: &mut EngineState) -> Result<()> {
+pub(crate) fn evaluate(engine_state: &mut EngineState) -> Result<()> {
     use crate::logger::{configure, logger};
     use reedline::{FileBackedHistory, Reedline, Signal};
 
@@ -97,7 +91,9 @@ pub(crate) fn evaluate(ctrlc: Arc<AtomicBool>, engine_state: &mut EngineState) -
         };
 
         //Reset the ctrl-c handler
-        ctrlc.store(false, Ordering::SeqCst);
+        if let Some(ctrlc) = &mut engine_state.ctrlc {
+            ctrlc.store(false, Ordering::SeqCst);
+        }
 
         let line_editor = Reedline::create()
             .into_diagnostic()?

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -72,7 +72,7 @@ fn in_variable_6() -> TestResult {
 
 #[test]
 fn help_works_with_missing_requirements() -> TestResult {
-    run_test(r#"each --help | lines | length"#, "15")
+    run_test(r#"each --help | lines | length"#, "17")
 }
 
 #[test]


### PR DESCRIPTION
# Description

This adds a few more commandline flags to the nu binary:

* -l/--login - make this a login shell
* -i/--interactive - make it an interactive shell
* -c/--commands - run some commands, then exit

I also tweaked some of the help formatting to be a little nicer, namely flag descriptions now follow flags, and have an indentation.
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
