### PR TITLE
Allow let/let-env to see custom command input

### DIFF
--- a/crates/nu-command/src/core_commands/let_.rs
+++ b/crates/nu-command/src/core_commands/let_.rs
@@ -1,4 +1,4 @@
-use nu_engine::eval_expression;
+use nu_engine::eval_expression_with_input;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{Category, Example, PipelineData, Signature, SyntaxShape};
@@ -31,7 +31,7 @@ impl Command for Let {
         engine_state: &EngineState,
         stack: &mut Stack,
         call: &Call,
-        _input: PipelineData,
+        input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
         let var_id = call.positional[0]
             .as_var()
@@ -41,11 +41,11 @@ impl Command for Let {
             .as_keyword()
             .expect("internal error: missing keyword");
 
-        let rhs = eval_expression(engine_state, stack, keyword_expr)?;
+        let rhs = eval_expression_with_input(engine_state, stack, keyword_expr, input, false)?;
 
         //println!("Adding: {:?} to {}", rhs, var_id);
 
-        stack.add_var(var_id, rhs);
+        stack.add_var(var_id, rhs.into_value(call.head));
         Ok(PipelineData::new(call.head))
     }
 

--- a/crates/nu-command/src/env/let_env.rs
+++ b/crates/nu-command/src/env/let_env.rs
@@ -1,4 +1,4 @@
-use nu_engine::{current_dir, eval_expression};
+use nu_engine::{current_dir, eval_expression_with_input};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{Category, PipelineData, Signature, SyntaxShape, Value};
@@ -31,7 +31,7 @@ impl Command for LetEnv {
         engine_state: &EngineState,
         stack: &mut Stack,
         call: &Call,
-        _input: PipelineData,
+        input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
         let env_var = call.positional[0]
             .as_string()
@@ -41,7 +41,8 @@ impl Command for LetEnv {
             .as_keyword()
             .expect("internal error: missing keyword");
 
-        let rhs = eval_expression(engine_state, stack, keyword_expr)?;
+        let rhs = eval_expression_with_input(engine_state, stack, keyword_expr, input, false)?
+            .into_value(call.head);
 
         if env_var == "PWD" {
             let cwd = current_dir(engine_state, stack)?;

--- a/crates/nu-engine/src/lib.rs
+++ b/crates/nu-engine/src/lib.rs
@@ -9,5 +9,5 @@ pub use call_ext::CallExt;
 pub use column::get_columns;
 pub use documentation::{generate_docs, get_brief_help, get_documentation, get_full_help};
 pub use env::*;
-pub use eval::{eval_block, eval_expression, eval_operator};
+pub use eval::{eval_block, eval_expression, eval_expression_with_input, eval_operator};
 pub use glob_from::glob_from;

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -166,3 +166,11 @@ fn divide_filesize() -> TestResult {
 fn date_comparison() -> TestResult {
     run_test(r#"(date now) < ((date now) + 2min)"#, "true")
 }
+
+#[test]
+fn let_sees_input() -> TestResult {
+    run_test(
+        r#"def c [] { let x = str length; $x }; "hello world" | c"#,
+        "11",
+    )
+}


### PR DESCRIPTION
# Description

This adds a new engine commands `eval_expression_with_input`, which allows for passing input into some types of expressions. With this, we can now allow `let` and `let-env` to pass the input they're given into the rhs of the assignments.

```
def c [] {
  let x = str length  # read in from the input given to the custom command and process it
  $x  # return result
}

"hello world" | c
```  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
