### PR TITLE
Add suport for Filesize and Date for sort-by command

### DIFF
--- a/crates/nu-command/src/filters/sort_by.rs
+++ b/crates/nu-command/src/filters/sort_by.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, FixedOffset};
 use nu_engine::column::column_does_not_exist;
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
@@ -157,6 +158,8 @@ pub enum CompareValues {
     // Floats(f64, f64),
     String(String, String),
     Booleans(bool, bool),
+    Filesize(i64, i64),
+    Date(DateTime<FixedOffset>, DateTime<FixedOffset>),
 }
 
 impl CompareValues {
@@ -167,6 +170,8 @@ impl CompareValues {
             // CompareValues::Floats(left, right) => left.cmp(right),
             CompareValues::String(left, right) => left.cmp(right),
             CompareValues::Booleans(left, right) => left.cmp(right),
+            CompareValues::Filesize(left, right) => left.cmp(right),
+            CompareValues::Date(left, right) => left.cmp(right),
         }
     }
 }
@@ -176,11 +181,17 @@ pub fn coerce_compare(
     right: &Value,
 ) -> Result<CompareValues, (&'static str, &'static str)> {
     match (left, right) {
-        /*
-        (Value::Float { val: left, .. }, Value::Float { val: right, .. }) => {
-            Ok(CompareValues::Floats(*left, *right))
+        // (Value::Float { val: left, .. }, Value::Float { val: right, .. }) => {
+        //     Ok(CompareValues::Floats(*left, *right))
+        // }
+        (Value::Filesize { val: left, .. }, Value::Filesize { val: right, .. }) => {
+            Ok(CompareValues::Filesize(*left, *right))
         }
-        */
+
+        (Value::Date { val: left, .. }, Value::Date { val: right, .. }) => {
+            Ok(CompareValues::Date(*left, *right))
+        }
+
         (Value::Int { val: left, .. }, Value::Int { val: right, .. }) => {
             Ok(CompareValues::Ints(*left, *right))
         }


### PR DESCRIPTION
# Description

Add support for Date and Filesize comparison for `sort-by` command - see  #818
Closes #843
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
