### PR TITLE
Also set $in-variable with input

### DIFF
--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -440,6 +440,7 @@ pub fn eval_expression_with_input(
         }
 
         elem => {
+            stack.add_var(nu_protocol::IN_VARIABLE_ID, input.into_value(expr.span));
             input = eval_expression(engine_state, stack, elem)?.into_pipeline_data();
         }
     }

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -440,7 +440,6 @@ pub fn eval_expression_with_input(
         }
 
         elem => {
-            stack.add_var(nu_protocol::IN_VARIABLE_ID, input.into_value(expr.span));
             input = eval_expression(engine_state, stack, elem)?.into_pipeline_data();
         }
     }

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -174,3 +174,11 @@ fn let_sees_input() -> TestResult {
         "11",
     )
 }
+
+#[test]
+fn let_sees_in_variable() -> TestResult {
+    run_test(
+        r#"def c [] { let x = $in.name; $x | str length }; {name: bob, size: 100 } | c"#,
+        "7",
+    )
+}

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -179,6 +179,6 @@ fn let_sees_input() -> TestResult {
 fn let_sees_in_variable() -> TestResult {
     run_test(
         r#"def c [] { let x = $in.name; $x | str length }; {name: bob, size: 100 } | c"#,
-        "7",
+        "3",
     )
 }

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -182,3 +182,11 @@ fn let_sees_in_variable() -> TestResult {
         "3",
     )
 }
+
+#[test]
+fn let_sees_in_variable2() -> TestResult {
+    run_test(
+        r#"def c [] { let x = ($in | str length); $x }; 'bob' | c"#,
+        "3",
+    )
+}


### PR DESCRIPTION
# Description

For `eval_expression_with_input`, also assign the `$in` variable to that input if you fall through to eval an expression. This allows using patterns like `let x = $in` at the start of your block if you want.
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
