### PR TITLE
Allow equals to separate long flag and arg

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -253,7 +253,11 @@ fn parse_long_flag(
     spans: &[Span],
     spans_idx: &mut usize,
     sig: &Signature,
-) -> (Option<String>, Option<Expression>, Option<ParseError>) {
+) -> (
+    Option<Spanned<String>>,
+    Option<Expression>,
+    Option<ParseError>,
+) {
     let arg_span = spans[*spans_idx];
     let arg_contents = working_set.get_span_contents(arg_span);
 
@@ -267,19 +271,41 @@ fn parse_long_flag(
                 if let Some(arg_shape) = &flag.arg {
                     if split.len() > 1 {
                         // and we also have the argument
+                        let long_name_len = long_name.len();
                         let mut span = arg_span;
-                        span.start += long_name.len() + 1; //offset by long flag and '='
+                        span.start += long_name_len + 3; //offset by long flag and '='
+
                         let (arg, err) = parse_value(working_set, span, arg_shape);
 
-                        (Some(long_name), Some(arg), err)
+                        (
+                            Some(Spanned {
+                                item: long_name,
+                                span: Span {
+                                    start: arg_span.start,
+                                    end: arg_span.start + long_name_len + 2,
+                                },
+                            }),
+                            Some(arg),
+                            err,
+                        )
                     } else if let Some(arg) = spans.get(*spans_idx + 1) {
                         let (arg, err) = parse_value(working_set, *arg, arg_shape);
 
                         *spans_idx += 1;
-                        (Some(long_name), Some(arg), err)
+                        (
+                            Some(Spanned {
+                                item: long_name,
+                                span: arg_span,
+                            }),
+                            Some(arg),
+                            err,
+                        )
                     } else {
                         (
-                            Some(long_name),
+                            Some(Spanned {
+                                item: long_name,
+                                span: arg_span,
+                            }),
                             None,
                             Some(ParseError::MissingFlagParam(
                                 arg_shape.to_string(),
@@ -289,11 +315,21 @@ fn parse_long_flag(
                     }
                 } else {
                     // A flag with no argument
-                    (Some(long_name), None, None)
+                    (
+                        Some(Spanned {
+                            item: long_name,
+                            span: arg_span,
+                        }),
+                        None,
+                        None,
+                    )
                 }
             } else {
                 (
-                    Some(long_name.clone()),
+                    Some(Spanned {
+                        item: long_name.clone(),
+                        span: arg_span,
+                    }),
                     None,
                     Some(ParseError::UnknownFlag(
                         sig.name.clone(),
@@ -303,7 +339,14 @@ fn parse_long_flag(
                 )
             }
         } else {
-            (Some("--".into()), None, Some(ParseError::NonUtf8(arg_span)))
+            (
+                Some(Spanned {
+                    item: "--".into(),
+                    span: arg_span,
+                }),
+                None,
+                Some(ParseError::NonUtf8(arg_span)),
+            )
         }
     } else {
         (None, None, None)
@@ -625,13 +668,7 @@ pub fn parse_internal_call(
         if let Some(long_name) = long_name {
             // We found a long flag, like --bar
             error = error.or(err);
-            call.named.push((
-                Spanned {
-                    item: long_name,
-                    span: arg_span,
-                },
-                arg,
-            ));
+            call.named.push((long_name, arg));
             spans_idx += 1;
             continue;
         }

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -184,3 +184,8 @@ fn commands_have_usage() -> TestResult {
         "cool usage",
     )
 }
+
+#[test]
+fn equals_separates_long_flag() -> TestResult {
+    run_test(r#"seq 1 4 --separator='+'"#, "1+2+3+4")
+}


### PR DESCRIPTION
# Description

You can now use `=` to separate a long flag from its argument, like so:

```
> seq 1 4 --separator='+'
```
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
