### PR TITLE
using menu trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2863,7 +2863,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.2.0"
-source = "git+https://github.com/nushell/reedline?branch=main#d7f42e5de4aeee9332dc8eaff07e68923401edcf"
+source = "git+https://github.com/nushell/reedline?branch=main#c0ec7dc2fd4181c11065f7e19c59fed2ffc83653"
 dependencies = [
  "chrono",
  "crossterm",

--- a/crates/nu-cli/src/prompt.rs
+++ b/crates/nu-cli/src/prompt.rs
@@ -14,10 +14,8 @@ pub struct NushellPrompt {
     right_prompt_string: Option<String>,
     default_prompt_indicator: String,
     default_vi_insert_prompt_indicator: String,
-    default_vi_visual_prompt_indicator: String,
-    default_menu_prompt_indicator: String,
+    default_vi_normal_prompt_indicator: String,
     default_multiline_indicator: String,
-    default_history_prompt_indicator: String,
 }
 
 impl Default for NushellPrompt {
@@ -33,10 +31,8 @@ impl NushellPrompt {
             right_prompt_string: None,
             default_prompt_indicator: "〉".to_string(),
             default_vi_insert_prompt_indicator: ": ".to_string(),
-            default_vi_visual_prompt_indicator: "v ".to_string(),
-            default_menu_prompt_indicator: "| ".to_string(),
+            default_vi_normal_prompt_indicator: "〉".to_string(),
             default_multiline_indicator: "::: ".to_string(),
-            default_history_prompt_indicator: "? ".to_string(),
         }
     }
 
@@ -56,8 +52,8 @@ impl NushellPrompt {
         self.default_vi_insert_prompt_indicator = prompt_vi_insert_string;
     }
 
-    pub fn update_prompt_vi_visual(&mut self, prompt_vi_visual_string: String) {
-        self.default_vi_visual_prompt_indicator = prompt_vi_visual_string;
+    pub fn update_prompt_vi_normal(&mut self, prompt_vi_normal_string: String) {
+        self.default_vi_normal_prompt_indicator = prompt_vi_normal_string;
     }
 
     pub fn update_prompt_multiline(&mut self, prompt_multiline_indicator_string: String) {
@@ -71,20 +67,15 @@ impl NushellPrompt {
         prompt_indicator_string: String,
         prompt_multiline_indicator_string: String,
         prompt_vi: (String, String),
-        prompt_menus: (String, String),
     ) {
-        let (prompt_vi_insert_string, prompt_vi_visual_string) = prompt_vi;
-        let (prompt_indicator_menu, prompt_history_indicator_menu) = prompt_menus;
+        let (prompt_vi_insert_string, prompt_vi_normal_string) = prompt_vi;
 
         self.left_prompt_string = left_prompt_string;
         self.right_prompt_string = right_prompt_string;
         self.default_prompt_indicator = prompt_indicator_string;
         self.default_vi_insert_prompt_indicator = prompt_vi_insert_string;
-        self.default_vi_visual_prompt_indicator = prompt_vi_visual_string;
+        self.default_vi_normal_prompt_indicator = prompt_vi_normal_string;
         self.default_multiline_indicator = prompt_multiline_indicator_string;
-
-        self.default_menu_prompt_indicator = prompt_indicator_menu;
-        self.default_history_prompt_indicator = prompt_history_indicator_menu;
     }
 
     fn default_wrapped_custom_string(&self, str: String) -> String {
@@ -95,19 +86,27 @@ impl NushellPrompt {
 impl Prompt for NushellPrompt {
     fn render_prompt_left(&self) -> Cow<str> {
         if let Some(prompt_string) = &self.left_prompt_string {
-            prompt_string.into()
+            prompt_string.replace("\n", "\r\n").into()
         } else {
             let default = DefaultPrompt::new();
-            default.render_prompt_left().to_string().into()
+            default
+                .render_prompt_left()
+                .to_string()
+                .replace("\n", "\r\n")
+                .into()
         }
     }
 
     fn render_prompt_right(&self) -> Cow<str> {
         if let Some(prompt_string) = &self.right_prompt_string {
-            prompt_string.into()
+            prompt_string.replace("\n", "\r\n").into()
         } else {
             let default = DefaultPrompt::new();
-            default.render_prompt_right().to_string().into()
+            default
+                .render_prompt_right()
+                .to_string()
+                .replace("\n", "\r\n")
+                .into()
         }
     }
 
@@ -116,13 +115,10 @@ impl Prompt for NushellPrompt {
             PromptEditMode::Default => self.default_prompt_indicator.as_str().into(),
             PromptEditMode::Emacs => self.default_prompt_indicator.as_str().into(),
             PromptEditMode::Vi(vi_mode) => match vi_mode {
-                PromptViMode::Normal => self.default_prompt_indicator.as_str().into(),
+                PromptViMode::Normal => self.default_vi_normal_prompt_indicator.as_str().into(),
                 PromptViMode::Insert => self.default_vi_insert_prompt_indicator.as_str().into(),
-                PromptViMode::Visual => self.default_vi_visual_prompt_indicator.as_str().into(),
             },
             PromptEditMode::Custom(str) => self.default_wrapped_custom_string(str).into(),
-            PromptEditMode::Menu => self.default_menu_prompt_indicator.as_str().into(),
-            PromptEditMode::HistoryMenu => self.default_history_prompt_indicator.as_str().into(),
         }
     }
 

--- a/src/prompt_update.rs
+++ b/src/prompt_update.rs
@@ -12,16 +12,14 @@ pub(crate) const PROMPT_COMMAND: &str = "PROMPT_COMMAND";
 pub(crate) const PROMPT_COMMAND_RIGHT: &str = "PROMPT_COMMAND_RIGHT";
 pub(crate) const PROMPT_INDICATOR: &str = "PROMPT_INDICATOR";
 pub(crate) const PROMPT_INDICATOR_VI_INSERT: &str = "PROMPT_INDICATOR_VI_INSERT";
-pub(crate) const PROMPT_INDICATOR_VI_VISUAL: &str = "PROMPT_INDICATOR_VI_VISUAL";
-pub(crate) const PROMPT_INDICATOR_MENU: &str = "PROMPT_INDICATOR_MENU";
+pub(crate) const PROMPT_INDICATOR_VI_NORMAL: &str = "PROMPT_INDICATOR_VI_NORMAL";
 pub(crate) const PROMPT_MULTILINE_INDICATOR: &str = "PROMPT_MULTILINE_INDICATOR";
-pub(crate) const PROMPT_INDICATOR_HISTORY: &str = "PROMPT_INDICATOR_HISTORY";
 
 pub(crate) fn get_prompt_indicators(
     config: &Config,
     engine_state: &EngineState,
     stack: &Stack,
-) -> (String, String, String, String, String, String) {
+) -> (String, String, String, String) {
     let prompt_indicator = match stack.get_env_var(engine_state, PROMPT_INDICATOR) {
         Some(pi) => pi.into_string("", config),
         None => "〉".to_string(),
@@ -32,9 +30,9 @@ pub(crate) fn get_prompt_indicators(
         None => ": ".to_string(),
     };
 
-    let prompt_vi_visual = match stack.get_env_var(engine_state, PROMPT_INDICATOR_VI_VISUAL) {
+    let prompt_vi_normal = match stack.get_env_var(engine_state, PROMPT_INDICATOR_VI_NORMAL) {
         Some(pviv) => pviv.into_string("", config),
-        None => "v ".to_string(),
+        None => "〉".to_string(),
     };
 
     let prompt_multiline = match stack.get_env_var(engine_state, PROMPT_MULTILINE_INDICATOR) {
@@ -42,23 +40,11 @@ pub(crate) fn get_prompt_indicators(
         None => "::: ".to_string(),
     };
 
-    let prompt_menu = match stack.get_env_var(engine_state, PROMPT_INDICATOR_MENU) {
-        Some(pm) => pm.into_string("", config),
-        None => "| ".to_string(),
-    };
-
-    let prompt_history = match stack.get_env_var(engine_state, PROMPT_INDICATOR_HISTORY) {
-        Some(ph) => ph.into_string("", config),
-        None => "? ".to_string(),
-    };
-
     (
         prompt_indicator,
         prompt_vi_insert,
-        prompt_vi_visual,
+        prompt_vi_normal,
         prompt_multiline,
-        prompt_menu,
-        prompt_history,
     )
 }
 
@@ -107,10 +93,8 @@ pub(crate) fn update_prompt<'prompt>(
     let (
         prompt_indicator_string,
         prompt_vi_insert_string,
-        prompt_vi_visual_string,
+        prompt_vi_normal_string,
         prompt_multiline_string,
-        prompt_indicator_menu,
-        prompt_indicator_history,
     ) = get_prompt_indicators(config, engine_state, stack);
 
     let mut stack = stack.clone();
@@ -121,8 +105,7 @@ pub(crate) fn update_prompt<'prompt>(
         get_prompt_string(PROMPT_COMMAND_RIGHT, config, engine_state, &mut stack),
         prompt_indicator_string,
         prompt_multiline_string,
-        (prompt_vi_insert_string, prompt_vi_visual_string),
-        (prompt_indicator_menu, prompt_indicator_history),
+        (prompt_vi_insert_string, prompt_vi_normal_string),
     );
 
     nu_prompt as &dyn Prompt

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -1,5 +1,6 @@
 use std::{sync::atomic::Ordering, time::Instant};
 
+use crate::reedline_config::{add_context_menu, add_history_menu};
 use crate::{config_files, prompt_update, reedline_config};
 use crate::{
     reedline_config::KeybindingsMode,
@@ -7,7 +8,7 @@ use crate::{
 };
 use log::trace;
 use miette::{IntoDiagnostic, Result};
-use nu_cli::{NuCompleter, NuHighlighter, NuValidator, NushellPrompt};
+use nu_cli::{NuHighlighter, NuValidator, NushellPrompt};
 use nu_color_config::get_color_config;
 use nu_engine::convert_env_values;
 use nu_parser::lex;
@@ -95,14 +96,8 @@ pub(crate) fn evaluate(engine_state: &mut EngineState) -> Result<()> {
             ctrlc.store(false, Ordering::SeqCst);
         }
 
-        let line_editor = Reedline::create()
+        let mut line_editor = Reedline::create()
             .into_diagnostic()?
-            // .with_completion_action_handler(Box::new(fuzzy_completion::FuzzyCompletion {
-            //     completer: Box::new(NuCompleter::new(engine_state.clone())),
-            // }))
-            // .with_completion_action_handler(Box::new(
-            //     ListCompletionHandler::default().with_completer(Box::new(completer)),
-            // ))
             .with_highlighter(Box::new(NuHighlighter {
                 engine_state: engine_state.clone(),
                 config: config.clone(),
@@ -111,19 +106,17 @@ pub(crate) fn evaluate(engine_state: &mut EngineState) -> Result<()> {
             .with_validator(Box::new(NuValidator {
                 engine_state: engine_state.clone(),
             }))
-            .with_ansi_colors(config.use_ansi_coloring)
-            .with_menu_completer(
-                Box::new(NuCompleter::new(engine_state.clone())),
-                reedline_config::create_menu_input(&config),
-            )
-            .with_history_menu(reedline_config::create_history_input(&config));
+            .with_ansi_colors(config.use_ansi_coloring);
+
+        line_editor = add_context_menu(line_editor, engine_state, &config);
+        line_editor = add_history_menu(line_editor, &config);
 
         //FIXME: if config.use_ansi_coloring is false then we should
         // turn off the hinter but I don't see any way to do that yet.
 
         let color_hm = get_color_config(&config);
 
-        let line_editor = if let Some(history_path) = history_path.clone() {
+        line_editor = if let Some(history_path) = history_path.clone() {
             let history = std::fs::read_to_string(&history_path);
             if history.is_ok() {
                 line_editor
@@ -146,7 +139,7 @@ pub(crate) fn evaluate(engine_state: &mut EngineState) -> Result<()> {
         };
 
         // Changing the line editor based on the found keybindings
-        let mut line_editor = match reedline_config::create_keybindings(&config) {
+        line_editor = match reedline_config::create_keybindings(&config) {
             Ok(keybindings) => match keybindings {
                 KeybindingsMode::Emacs(keybindings) => {
                     let edit_mode = Box::new(Emacs::new(keybindings));


### PR DESCRIPTION
Improvements to menus
- history menu is activated with ctr+i
- history search is not limited to one page
- menus markers can be changed in config file

Extra changes
- Removed unused visual mode
- Indicator for normal mode in vi
