### PR TITLE
Move history search to ctrl-x

### DIFF
--- a/src/reedline_config.rs
+++ b/src/reedline_config.rs
@@ -134,7 +134,7 @@ pub(crate) fn add_history_menu(line_editor: Reedline, config: &Config) -> Reedli
 fn add_menu_keybindings(keybindings: &mut Keybindings) {
     keybindings.add_binding(
         KeyModifiers::CONTROL,
-        KeyCode::Char('i'),
+        KeyCode::Char('x'),
         ReedlineEvent::UntilFound(vec![
             ReedlineEvent::Menu("history_menu".to_string()),
             ReedlineEvent::MenuPageNext,
@@ -143,7 +143,7 @@ fn add_menu_keybindings(keybindings: &mut Keybindings) {
 
     keybindings.add_binding(
         KeyModifiers::CONTROL | KeyModifiers::SHIFT,
-        KeyCode::Char('i'),
+        KeyCode::Char('x'),
         ReedlineEvent::MenuPagePrevious,
     );
 


### PR DESCRIPTION
# Description

Moves history search to ctrl-x
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
