### PR TITLE
Add F1-F12 key support

### DIFF
--- a/src/reedline_config.rs
+++ b/src/reedline_config.rs
@@ -247,14 +247,19 @@ fn add_keybinding(
         "backspace" => KeyCode::Backspace,
         "enter" => KeyCode::Enter,
         c if c.starts_with("char_") => {
-            let char = c.replace("char_", "");
-            let char = char.chars().next().ok_or({
-                ShellError::UnsupportedConfigValue(
+            let mut char_iter = c.chars().skip(5);
+            let pos1 = char_iter.next();
+            let pos2 = char_iter.next();
+
+            let char = match (pos1, pos2) {
+                (Some(char), None) => Ok(char),
+                _ => Err(ShellError::UnsupportedConfigValue(
                     "char_<CHAR: unicode codepoint>".to_string(),
                     c.to_string(),
                     keybinding.keycode.span()?,
-                )
-            })?;
+                )),
+            }?;
+
             KeyCode::Char(char)
         }
         "down" => KeyCode::Down,

--- a/src/reedline_config.rs
+++ b/src/reedline_config.rs
@@ -231,8 +231,8 @@ fn add_keybinding(
         "control | alt | shift" => KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT,
         _ => {
             return Err(ShellError::UnsupportedConfigValue(
-                keybinding.modifier.into_abbreviated_string(config),
                 "CONTROL, SHIFT, ALT or NONE".to_string(),
+                keybinding.modifier.into_abbreviated_string(config),
                 keybinding.modifier.span()?,
             ))
         }
@@ -250,8 +250,8 @@ fn add_keybinding(
             let char = c.replace("char_", "");
             let char = char.chars().next().ok_or({
                 ShellError::UnsupportedConfigValue(
+                    "char_<CHAR: unicode codepoint>".to_string(),
                     c.to_string(),
-                    "char_ plus char".to_string(),
                     keybinding.keycode.span()?,
                 )
             })?;
@@ -275,8 +275,8 @@ fn add_keybinding(
                 .ok()
                 .filter(|num| matches!(num, 1..=12))
                 .ok_or(ShellError::UnsupportedConfigValue(
-                    c.to_string(),
-                    "Unknown function key (f1,f2,...,f12)".to_string(),
+                    "(f1|f2|...|f12)".to_string(),
+                    format!("unknown function key: {}", c),
                     keybinding.keycode.span()?,
                 ))?;
             KeyCode::F(fn_num)
@@ -285,8 +285,8 @@ fn add_keybinding(
         "esc" | "escape" => KeyCode::Esc,
         _ => {
             return Err(ShellError::UnsupportedConfigValue(
-                keybinding.keycode.into_abbreviated_string(config),
                 "crossterm KeyCode".to_string(),
+                keybinding.keycode.into_abbreviated_string(config),
                 keybinding.keycode.span()?,
             ))
         }
@@ -386,8 +386,8 @@ fn parse_event(value: Value, config: &Config) -> Result<ReedlineEvent, ShellErro
             }
         }
         v => Err(ShellError::UnsupportedConfigValue(
-            v.into_abbreviated_string(config),
             "record or list of records".to_string(),
+            v.into_abbreviated_string(config),
             v.span()?,
         )),
     }
@@ -475,8 +475,8 @@ fn parse_edit(edit: &Value, config: &Config) -> Result<EditCommand, ShellError> 
                 }
                 e => {
                     return Err(ShellError::UnsupportedConfigValue(
-                        e.to_string(),
                         "reedline EditCommand".to_string(),
+                        e.to_string(),
                         edit.span()?,
                     ))
                 }
@@ -484,8 +484,8 @@ fn parse_edit(edit: &Value, config: &Config) -> Result<EditCommand, ShellError> 
         }
         e => {
             return Err(ShellError::UnsupportedConfigValue(
-                e.into_abbreviated_string(config),
                 "record with EditCommand".to_string(),
+                e.into_abbreviated_string(config),
                 edit.span()?,
             ))
         }

--- a/src/reedline_config.rs
+++ b/src/reedline_config.rs
@@ -269,7 +269,18 @@ fn add_keybinding(
         "backtab" => KeyCode::BackTab,
         "delete" => KeyCode::Delete,
         "insert" => KeyCode::Insert,
-        // TODO: Add KeyCode::F(u8) for function keys
+        c if c.starts_with('f') => {
+            let fn_num: u8 = c[1..]
+                .parse()
+                .ok()
+                .filter(|num| matches!(num, 1..=12))
+                .ok_or(ShellError::UnsupportedConfigValue(
+                    c.to_string(),
+                    "Unknown function key (f1,f2,...,f12)".to_string(),
+                    keybinding.keycode.span()?,
+                ))?;
+            KeyCode::F(fn_num)
+        }
         "null" => KeyCode::Null,
         "esc" | "escape" => KeyCode::Esc,
         _ => {


### PR DESCRIPTION
# Description

As we are short on keybinding options support the F\d-keys as well
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
