### PR TITLE
Harden highlighter against alias spans

### DIFF
--- a/crates/nu-cli/src/syntax_highlight.rs
+++ b/crates/nu-cli/src/syntax_highlight.rs
@@ -27,7 +27,10 @@ impl Highlighter for NuHighlighter {
         let mut last_seen_span = global_span_offset;
 
         for shape in &shapes {
-            if shape.0.end <= last_seen_span {
+            if shape.0.end <= last_seen_span
+                || last_seen_span < global_span_offset
+                || shape.0.start < global_span_offset
+            {
                 // We've already output something for this span
                 // so just skip this one
                 continue;


### PR DESCRIPTION
# Description

Hardens the syntax highlighter against spans that come from aliases (which are in a different part of source than is currently highlighted). For now, this will result in them being highlighted white.

Fixes #859 
Fixes #770 
Fixes #771 
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
