### PR TITLE
"maybe text code" version 2

### DIFF
--- a/crates/nu-command/src/conversions/into/binary.rs
+++ b/crates/nu-command/src/conversions/into/binary.rs
@@ -2,7 +2,8 @@ use nu_engine::CallExt;
 use nu_protocol::{
     ast::{Call, CellPath},
     engine::{Command, EngineState, Stack},
-    Category, Example, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
+    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Span, SyntaxShape,
+    Value,
 };
 
 #[derive(Clone)]
@@ -98,7 +99,15 @@ fn into_binary(
     let column_paths: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
 
     match input {
-        PipelineData::RawStream(..) => Ok(input),
+        PipelineData::RawStream(stream, ..) => {
+            // TODO: in the future, we may want this to stream out, converting each to bytes
+            let output = stream.into_bytes()?;
+            Ok(Value::Binary {
+                val: output,
+                span: head,
+            }
+            .into_pipeline_data())
+        }
         _ => input.map(
             move |v| {
                 if column_paths.is_empty() {

--- a/crates/nu-command/src/conversions/into/binary.rs
+++ b/crates/nu-command/src/conversions/into/binary.rs
@@ -98,7 +98,7 @@ fn into_binary(
     let column_paths: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
 
     match input {
-        PipelineData::ByteStream(..) => Ok(input),
+        PipelineData::RawStream(..) => Ok(input),
         _ => input.map(
             move |v| {
                 if column_paths.is_empty() {

--- a/crates/nu-command/src/core_commands/describe.rs
+++ b/crates/nu-command/src/core_commands/describe.rs
@@ -26,9 +26,9 @@ impl Command for Describe {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
-        if matches!(input, PipelineData::ByteStream(..)) {
+        if matches!(input, PipelineData::RawStream(..)) {
             Ok(PipelineData::Value(
-                Value::string("binary", call.head),
+                Value::string("raw input", call.head),
                 None,
             ))
         } else {

--- a/crates/nu-command/src/core_commands/echo.rs
+++ b/crates/nu-command/src/core_commands/echo.rs
@@ -2,7 +2,7 @@ use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, PipelineData, ShellError, Signature, SyntaxShape, Value, ValueStream,
+    Category, Example, ListStream, PipelineData, ShellError, Signature, SyntaxShape, Value,
 };
 
 #[derive(Clone)]
@@ -35,7 +35,7 @@ impl Command for Echo {
             match n.cmp(&1usize) {
                 //  More than one value is converted in a stream of values
                 std::cmp::Ordering::Greater => PipelineData::ListStream(
-                    ValueStream::from_stream(to_be_echoed.into_iter(), engine_state.ctrlc.clone()),
+                    ListStream::from_stream(to_be_echoed.into_iter(), engine_state.ctrlc.clone()),
                     None,
                 ),
 

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -2,8 +2,8 @@ use nu_engine::{get_full_help, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    ByteStream, Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Spanned,
-    SyntaxShape, Value,
+    ByteStream, Category, Example, IntoPipelineData, PipelineData, RawStream, ShellError,
+    Signature, Spanned, SyntaxShape, Value,
 };
 use std::io::{BufRead, BufReader, Read};
 
@@ -120,11 +120,8 @@ impl Command for Open {
 
             let buf_reader = BufReader::new(file);
 
-            let output = PipelineData::ByteStream(
-                ByteStream {
-                    stream: Box::new(BufferedReader { input: buf_reader }),
-                    ctrlc,
-                },
+            let output = PipelineData::RawStream(
+                RawStream::new(Box::new(BufferedReader { input: buf_reader }), ctrlc),
                 call_span,
                 None,
             );

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -2,8 +2,8 @@ use nu_engine::{get_full_help, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    ByteStream, Category, Example, IntoPipelineData, PipelineData, RawStream, ShellError,
-    Signature, Spanned, SyntaxShape, Value,
+    Category, Example, IntoPipelineData, PipelineData, RawStream, ShellError, Signature, Spanned,
+    SyntaxShape, Value,
 };
 use std::io::{BufRead, BufReader, Read};
 

--- a/crates/nu-command/src/filters/columns.rs
+++ b/crates/nu-command/src/filters/columns.rs
@@ -82,7 +82,7 @@ fn getcol(
                 .map(move |x| Value::String { val: x, span })
                 .into_pipeline_data(engine_state.ctrlc.clone()))
         }
-        PipelineData::Value(..) | PipelineData::StringStream(..) | PipelineData::ByteStream(..) => {
+        PipelineData::Value(..) | PipelineData::RawStream(..) => {
             let cols = vec![];
             let vals = vec![];
             Ok(Value::Record { cols, vals, span }.into_pipeline_data())

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -111,14 +111,14 @@ impl Command for Each {
                     }
                 })
                 .into_pipeline_data(ctrlc)),
-            PipelineData::ByteStream(stream, ..) => Ok(stream
+            PipelineData::RawStream(stream, ..) => Ok(stream
                 .into_iter()
                 .enumerate()
                 .map(move |(idx, x)| {
                     stack.with_env(&orig_env_vars, &orig_env_hidden);
 
                     let x = match x {
-                        Ok(x) => Value::Binary { val: x, span },
+                        Ok(x) => x,
                         Err(err) => return Value::Error { error: err },
                     };
 
@@ -151,46 +151,46 @@ impl Command for Each {
                     }
                 })
                 .into_pipeline_data(ctrlc)),
-            PipelineData::StringStream(stream, ..) => Ok(stream
-                .into_iter()
-                .enumerate()
-                .map(move |(idx, x)| {
-                    stack.with_env(&orig_env_vars, &orig_env_hidden);
+            // PipelineData::StringStream(stream, ..) => Ok(stream
+            //     .into_iter()
+            //     .enumerate()
+            //     .map(move |(idx, x)| {
+            //         stack.with_env(&orig_env_vars, &orig_env_hidden);
 
-                    let x = match x {
-                        Ok(x) => Value::String { val: x, span },
-                        Err(err) => return Value::Error { error: err },
-                    };
+            //         let x = match x {
+            //             Ok(x) => Value::String { val: x, span },
+            //             Err(err) => return Value::Error { error: err },
+            //         };
 
-                    if let Some(var) = block.signature.get_positional(0) {
-                        if let Some(var_id) = &var.var_id {
-                            if numbered {
-                                stack.add_var(
-                                    *var_id,
-                                    Value::Record {
-                                        cols: vec!["index".into(), "item".into()],
-                                        vals: vec![
-                                            Value::Int {
-                                                val: idx as i64,
-                                                span,
-                                            },
-                                            x,
-                                        ],
-                                        span,
-                                    },
-                                );
-                            } else {
-                                stack.add_var(*var_id, x);
-                            }
-                        }
-                    }
+            //         if let Some(var) = block.signature.get_positional(0) {
+            //             if let Some(var_id) = &var.var_id {
+            //                 if numbered {
+            //                     stack.add_var(
+            //                         *var_id,
+            //                         Value::Record {
+            //                             cols: vec!["index".into(), "item".into()],
+            //                             vals: vec![
+            //                                 Value::Int {
+            //                                     val: idx as i64,
+            //                                     span,
+            //                                 },
+            //                                 x,
+            //                             ],
+            //                             span,
+            //                         },
+            //                     );
+            //                 } else {
+            //                     stack.add_var(*var_id, x);
+            //                 }
+            //             }
+            //         }
 
-                    match eval_block(&engine_state, &mut stack, &block, PipelineData::new(span)) {
-                        Ok(v) => v.into_value(span),
-                        Err(error) => Value::Error { error },
-                    }
-                })
-                .into_pipeline_data(ctrlc)),
+            //         match eval_block(&engine_state, &mut stack, &block, PipelineData::new(span)) {
+            //             Ok(v) => v.into_value(span),
+            //             Err(error) => Value::Error { error },
+            //         }
+            //     })
+            //     .into_pipeline_data(ctrlc)),
             PipelineData::Value(Value::Record { cols, vals, .. }, ..) => {
                 let mut output_cols = vec![];
                 let mut output_vals = vec![];

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -151,46 +151,6 @@ impl Command for Each {
                     }
                 })
                 .into_pipeline_data(ctrlc)),
-            // PipelineData::StringStream(stream, ..) => Ok(stream
-            //     .into_iter()
-            //     .enumerate()
-            //     .map(move |(idx, x)| {
-            //         stack.with_env(&orig_env_vars, &orig_env_hidden);
-
-            //         let x = match x {
-            //             Ok(x) => Value::String { val: x, span },
-            //             Err(err) => return Value::Error { error: err },
-            //         };
-
-            //         if let Some(var) = block.signature.get_positional(0) {
-            //             if let Some(var_id) = &var.var_id {
-            //                 if numbered {
-            //                     stack.add_var(
-            //                         *var_id,
-            //                         Value::Record {
-            //                             cols: vec!["index".into(), "item".into()],
-            //                             vals: vec![
-            //                                 Value::Int {
-            //                                     val: idx as i64,
-            //                                     span,
-            //                                 },
-            //                                 x,
-            //                             ],
-            //                             span,
-            //                         },
-            //                     );
-            //                 } else {
-            //                     stack.add_var(*var_id, x);
-            //                 }
-            //             }
-            //         }
-
-            //         match eval_block(&engine_state, &mut stack, &block, PipelineData::new(span)) {
-            //             Ok(v) => v.into_value(span),
-            //             Err(error) => Value::Error { error },
-            //         }
-            //     })
-            //     .into_pipeline_data(ctrlc)),
             PipelineData::Value(Value::Record { cols, vals, .. }, ..) => {
                 let mut output_cols = vec![];
                 let mut output_vals = vec![];

--- a/crates/nu-command/src/filters/length.rs
+++ b/crates/nu-command/src/filters/length.rs
@@ -96,7 +96,7 @@ fn getcol(
                 .map(move |x| Value::String { val: x, span })
                 .into_pipeline_data(engine_state.ctrlc.clone()))
         }
-        PipelineData::Value(..) | PipelineData::StringStream(..) | PipelineData::ByteStream(..) => {
+        PipelineData::Value(..) | PipelineData::RawStream(..) => {
             let cols = vec![];
             let vals = vec![];
             Ok(Value::Record { cols, vals, span }.into_pipeline_data())

--- a/crates/nu-command/src/filters/lines.rs
+++ b/crates/nu-command/src/filters/lines.rs
@@ -88,41 +88,41 @@ impl Command for Lines {
 
                 Ok(iter.into_pipeline_data(engine_state.ctrlc.clone()))
             }
-            PipelineData::StringStream(stream, span, ..) => {
-                let mut split_char = "\n";
+            // PipelineData::StringStream(stream, span, ..) => {
+            //     let mut split_char = "\n";
 
-                let iter = stream
-                    .into_iter()
-                    .map(move |value| match value {
-                        Ok(value) => {
-                            if split_char != "\r\n" && value.contains("\r\n") {
-                                split_char = "\r\n";
-                            }
-                            value
-                                .split(split_char)
-                                .filter_map(|s| {
-                                    if !s.is_empty() {
-                                        Some(Value::String {
-                                            val: s.into(),
-                                            span,
-                                        })
-                                    } else {
-                                        None
-                                    }
-                                })
-                                .collect::<Vec<Value>>()
-                        }
-                        Err(err) => vec![Value::Error { error: err }],
-                    })
-                    .flatten();
+            //     let iter = stream
+            //         .into_iter()
+            //         .map(move |value| match value {
+            //             Ok(value) => {
+            //                 if split_char != "\r\n" && value.contains("\r\n") {
+            //                     split_char = "\r\n";
+            //                 }
+            //                 value
+            //                     .split(split_char)
+            //                     .filter_map(|s| {
+            //                         if !s.is_empty() {
+            //                             Some(Value::String {
+            //                                 val: s.into(),
+            //                                 span,
+            //                             })
+            //                         } else {
+            //                             None
+            //                         }
+            //                     })
+            //                     .collect::<Vec<Value>>()
+            //             }
+            //             Err(err) => vec![Value::Error { error: err }],
+            //         })
+            //         .flatten();
 
-                Ok(iter.into_pipeline_data(engine_state.ctrlc.clone()))
-            }
+            //     Ok(iter.into_pipeline_data(engine_state.ctrlc.clone()))
+            // }
             PipelineData::Value(val, ..) => Err(ShellError::UnsupportedInput(
                 format!("Not supported input: {}", val.as_string()?),
                 call.head,
             )),
-            PipelineData::ByteStream(..) => {
+            PipelineData::RawStream(..) => {
                 let config = stack.get_config()?;
 
                 //FIXME: Make sure this can fail in the future to let the user

--- a/crates/nu-command/src/filters/lines.rs
+++ b/crates/nu-command/src/filters/lines.rs
@@ -88,36 +88,6 @@ impl Command for Lines {
 
                 Ok(iter.into_pipeline_data(engine_state.ctrlc.clone()))
             }
-            // PipelineData::StringStream(stream, span, ..) => {
-            //     let mut split_char = "\n";
-
-            //     let iter = stream
-            //         .into_iter()
-            //         .map(move |value| match value {
-            //             Ok(value) => {
-            //                 if split_char != "\r\n" && value.contains("\r\n") {
-            //                     split_char = "\r\n";
-            //                 }
-            //                 value
-            //                     .split(split_char)
-            //                     .filter_map(|s| {
-            //                         if !s.is_empty() {
-            //                             Some(Value::String {
-            //                                 val: s.into(),
-            //                                 span,
-            //                             })
-            //                         } else {
-            //                             None
-            //                         }
-            //                     })
-            //                     .collect::<Vec<Value>>()
-            //             }
-            //             Err(err) => vec![Value::Error { error: err }],
-            //         })
-            //         .flatten();
-
-            //     Ok(iter.into_pipeline_data(engine_state.ctrlc.clone()))
-            // }
             PipelineData::Value(val, ..) => Err(ShellError::UnsupportedInput(
                 format!("Not supported input: {}", val.as_string()?),
                 call.head,

--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -177,56 +177,56 @@ impl Command for ParEach {
                 .into_iter()
                 .flatten()
                 .into_pipeline_data(ctrlc)),
-            PipelineData::StringStream(stream, ..) => Ok(stream
+            // PipelineData::StringStream(stream, ..) => Ok(stream
+            //     .enumerate()
+            //     .par_bridge()
+            //     .map(move |(idx, x)| {
+            //         let x = match x {
+            //             Ok(x) => Value::String { val: x, span },
+            //             Err(err) => return Value::Error { error: err }.into_pipeline_data(),
+            //         };
+            //         let block = engine_state.get_block(block_id);
+
+            //         let mut stack = stack.clone();
+
+            //         if let Some(var) = block.signature.get_positional(0) {
+            //             if let Some(var_id) = &var.var_id {
+            //                 if numbered {
+            //                     stack.add_var(
+            //                         *var_id,
+            //                         Value::Record {
+            //                             cols: vec!["index".into(), "item".into()],
+            //                             vals: vec![
+            //                                 Value::Int {
+            //                                     val: idx as i64,
+            //                                     span,
+            //                                 },
+            //                                 x,
+            //                             ],
+            //                             span,
+            //                         },
+            //                     );
+            //                 } else {
+            //                     stack.add_var(*var_id, x);
+            //                 }
+            //             }
+            //         }
+
+            //         match eval_block(&engine_state, &mut stack, block, PipelineData::new(span)) {
+            //             Ok(v) => v,
+            //             Err(error) => Value::Error { error }.into_pipeline_data(),
+            //         }
+            //     })
+            //     .collect::<Vec<_>>()
+            //     .into_iter()
+            //     .flatten()
+            //     .into_pipeline_data(ctrlc)),
+            PipelineData::RawStream(stream, ..) => Ok(stream
                 .enumerate()
                 .par_bridge()
                 .map(move |(idx, x)| {
                     let x = match x {
-                        Ok(x) => Value::String { val: x, span },
-                        Err(err) => return Value::Error { error: err }.into_pipeline_data(),
-                    };
-                    let block = engine_state.get_block(block_id);
-
-                    let mut stack = stack.clone();
-
-                    if let Some(var) = block.signature.get_positional(0) {
-                        if let Some(var_id) = &var.var_id {
-                            if numbered {
-                                stack.add_var(
-                                    *var_id,
-                                    Value::Record {
-                                        cols: vec!["index".into(), "item".into()],
-                                        vals: vec![
-                                            Value::Int {
-                                                val: idx as i64,
-                                                span,
-                                            },
-                                            x,
-                                        ],
-                                        span,
-                                    },
-                                );
-                            } else {
-                                stack.add_var(*var_id, x);
-                            }
-                        }
-                    }
-
-                    match eval_block(&engine_state, &mut stack, block, PipelineData::new(span)) {
-                        Ok(v) => v,
-                        Err(error) => Value::Error { error }.into_pipeline_data(),
-                    }
-                })
-                .collect::<Vec<_>>()
-                .into_iter()
-                .flatten()
-                .into_pipeline_data(ctrlc)),
-            PipelineData::ByteStream(stream, ..) => Ok(stream
-                .enumerate()
-                .par_bridge()
-                .map(move |(idx, x)| {
-                    let x = match x {
-                        Ok(x) => Value::Binary { val: x, span },
+                        Ok(x) => x,
                         Err(err) => return Value::Error { error: err }.into_pipeline_data(),
                     };
 

--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -177,50 +177,6 @@ impl Command for ParEach {
                 .into_iter()
                 .flatten()
                 .into_pipeline_data(ctrlc)),
-            // PipelineData::StringStream(stream, ..) => Ok(stream
-            //     .enumerate()
-            //     .par_bridge()
-            //     .map(move |(idx, x)| {
-            //         let x = match x {
-            //             Ok(x) => Value::String { val: x, span },
-            //             Err(err) => return Value::Error { error: err }.into_pipeline_data(),
-            //         };
-            //         let block = engine_state.get_block(block_id);
-
-            //         let mut stack = stack.clone();
-
-            //         if let Some(var) = block.signature.get_positional(0) {
-            //             if let Some(var_id) = &var.var_id {
-            //                 if numbered {
-            //                     stack.add_var(
-            //                         *var_id,
-            //                         Value::Record {
-            //                             cols: vec!["index".into(), "item".into()],
-            //                             vals: vec![
-            //                                 Value::Int {
-            //                                     val: idx as i64,
-            //                                     span,
-            //                                 },
-            //                                 x,
-            //                             ],
-            //                             span,
-            //                         },
-            //                     );
-            //                 } else {
-            //                     stack.add_var(*var_id, x);
-            //                 }
-            //             }
-            //         }
-
-            //         match eval_block(&engine_state, &mut stack, block, PipelineData::new(span)) {
-            //             Ok(v) => v,
-            //             Err(error) => Value::Error { error }.into_pipeline_data(),
-            //         }
-            //     })
-            //     .collect::<Vec<_>>()
-            //     .into_iter()
-            //     .flatten()
-            //     .into_pipeline_data(ctrlc)),
             PipelineData::RawStream(stream, ..) => Ok(stream
                 .enumerate()
                 .par_bridge()

--- a/crates/nu-command/src/filters/wrap.rs
+++ b/crates/nu-command/src/filters/wrap.rs
@@ -50,13 +50,9 @@ impl Command for Wrap {
                     span,
                 })
                 .into_pipeline_data(engine_state.ctrlc.clone())),
-            PipelineData::StringStream(stream, ..) => Ok(Value::String {
-                val: stream.into_string("")?,
-                span,
-            }
-            .into_pipeline_data()),
-            PipelineData::ByteStream(stream, ..) => Ok(Value::Binary {
-                val: stream.into_vec()?,
+            PipelineData::RawStream(..) => Ok(Value::Record {
+                cols: vec![name],
+                vals: vec![input.into_value(call.head)],
                 span,
             }
             .into_pipeline_data()),

--- a/crates/nu-command/src/network/fetch.rs
+++ b/crates/nu-command/src/network/fetch.rs
@@ -2,7 +2,7 @@ use base64::encode;
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{ByteStream, RawStream};
+use nu_protocol::RawStream;
 
 use nu_protocol::{
     Category, Example, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,

--- a/crates/nu-command/src/network/fetch.rs
+++ b/crates/nu-command/src/network/fetch.rs
@@ -2,7 +2,7 @@ use base64::encode;
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::ByteStream;
+use nu_protocol::{ByteStream, RawStream};
 
 use nu_protocol::{
     Category, Example, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
@@ -356,13 +356,13 @@ fn response_to_buffer(
 ) -> nu_protocol::PipelineData {
     let buffered_input = BufReader::new(response);
 
-    PipelineData::ByteStream(
-        ByteStream {
-            stream: Box::new(BufferedReader {
+    PipelineData::RawStream(
+        RawStream::new(
+            Box::new(BufferedReader {
                 input: buffered_input,
             }),
-            ctrlc: engine_state.ctrlc.clone(),
-        },
+            engine_state.ctrlc.clone(),
+        ),
         span,
         None,
     )

--- a/crates/nu-command/src/path/join.rs
+++ b/crates/nu-command/src/path/join.rs
@@ -5,8 +5,8 @@ use std::{
 
 use nu_engine::CallExt;
 use nu_protocol::{
-    engine::Command, Example, PipelineData, ShellError, Signature, Span, Spanned, SyntaxShape,
-    Value, ValueStream,
+    engine::Command, Example, ListStream, PipelineData, ShellError, Signature, Span, Spanned,
+    SyntaxShape, Value,
 };
 
 use super::PathSubcommandArguments;
@@ -68,7 +68,7 @@ the output of 'path parse' and 'path split' subcommands."#
                 Ok(PipelineData::Value(handle_value(val, &args, head), md))
             }
             PipelineData::ListStream(stream, md) => Ok(PipelineData::ListStream(
-                ValueStream::from_stream(
+                ListStream::from_stream(
                     stream.map(move |val| handle_value(val, &args, head)),
                     engine_state.ctrlc.clone(),
                 ),

--- a/crates/nu-command/src/random/dice.rs
+++ b/crates/nu-command/src/random/dice.rs
@@ -2,7 +2,7 @@ use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, PipelineData, ShellError, Signature, SyntaxShape, Value, ValueStream,
+    Category, Example, ListStream, PipelineData, ShellError, Signature, SyntaxShape, Value,
 };
 use rand::prelude::{thread_rng, Rng};
 
@@ -80,7 +80,7 @@ fn dice(
     });
 
     Ok(PipelineData::ListStream(
-        ValueStream::from_stream(iter, engine_state.ctrlc.clone()),
+        ListStream::from_stream(iter, engine_state.ctrlc.clone()),
         None,
     ))
 }

--- a/crates/nu-command/src/strings/decode.rs
+++ b/crates/nu-command/src/strings/decode.rs
@@ -44,8 +44,8 @@ impl Command for Decode {
         let encoding: Spanned<String> = call.req(engine_state, stack, 0)?;
 
         match input {
-            PipelineData::ByteStream(stream, ..) => {
-                let bytes: Vec<u8> = stream.into_vec()?;
+            PipelineData::RawStream(stream, ..) => {
+                let bytes: Vec<u8> = stream.into_bytes()?;
 
                 let encoding = match Encoding::for_label(encoding.item.as_bytes()) {
                     None => Err(ShellError::SpannedLabeledError(

--- a/crates/nu-command/src/strings/format/command.rs
+++ b/crates/nu-command/src/strings/format/command.rs
@@ -2,7 +2,7 @@ use nu_engine::CallExt;
 use nu_protocol::ast::{Call, PathMember};
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, PipelineData, ShellError, Signature, Span, SyntaxShape, Value, ValueStream,
+    Category, Example, ListStream, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
 };
 
 #[derive(Clone)]
@@ -152,7 +152,7 @@ fn format(
             }
 
             Ok(PipelineData::ListStream(
-                ValueStream::from_stream(list.into_iter(), None),
+                ListStream::from_stream(list.into_iter(), None),
                 None,
             ))
         }

--- a/crates/nu-command/src/strings/parse.rs
+++ b/crates/nu-command/src/strings/parse.rs
@@ -2,8 +2,8 @@ use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, PipelineData, ShellError, Signature, Span, Spanned, SyntaxShape, Value,
-    ValueStream,
+    Category, Example, ListStream, PipelineData, ShellError, Signature, Span, Spanned, SyntaxShape,
+    Value,
 };
 use regex::Regex;
 
@@ -127,7 +127,7 @@ fn operate(
     }
 
     Ok(PipelineData::ListStream(
-        ValueStream::from_stream(parsed.into_iter(), ctrlc),
+        ListStream::from_stream(parsed.into_iter(), ctrlc),
         None,
     ))
 }

--- a/crates/nu-command/src/strings/str_/collect.rs
+++ b/crates/nu-command/src/strings/str_/collect.rs
@@ -39,6 +39,7 @@ impl Command for StrCollect {
 
         let config = stack.get_config().unwrap_or_default();
 
+        // let output = input.collect_string(&separator.unwrap_or_default(), &config)?;
         // Hmm, not sure what we actually want. If you don't use debug_string, Date comes out as human readable
         // which feels funny
         #[allow(clippy::needless_collect)]

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -8,7 +8,7 @@ use std::sync::mpsc;
 use nu_engine::env_to_strings;
 use nu_protocol::engine::{EngineState, Stack};
 use nu_protocol::{ast::Call, engine::Command, ShellError, Signature, SyntaxShape, Value};
-use nu_protocol::{ByteStream, Category, Config, PipelineData, Span, Spanned};
+use nu_protocol::{ByteStream, Category, Config, PipelineData, RawStream, Span, Spanned};
 
 use itertools::Itertools;
 
@@ -242,11 +242,8 @@ impl ExternalCommand {
                 });
                 let receiver = ChannelReceiver::new(rx);
 
-                Ok(PipelineData::ByteStream(
-                    ByteStream {
-                        stream: Box::new(receiver),
-                        ctrlc: output_ctrlc,
-                    },
+                Ok(PipelineData::RawStream(
+                    RawStream::new(Box::new(receiver), output_ctrlc),
                     head,
                     None,
                 ))

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -8,7 +8,7 @@ use std::sync::mpsc;
 use nu_engine::env_to_strings;
 use nu_protocol::engine::{EngineState, Stack};
 use nu_protocol::{ast::Call, engine::Command, ShellError, Signature, SyntaxShape, Value};
-use nu_protocol::{ByteStream, Category, Config, PipelineData, RawStream, Span, Spanned};
+use nu_protocol::{Category, Config, PipelineData, RawStream, Span, Spanned};
 
 use itertools::Itertools;
 

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -6,7 +6,7 @@ use nu_protocol::ast::{Call, PathMember};
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
     Category, Config, DataSource, IntoPipelineData, ListStream, PipelineData, PipelineMetadata,
-    RawStream, ShellError, Signature, Span, StringStream, SyntaxShape, Value,
+    RawStream, ShellError, Signature, Span, SyntaxShape, Value,
 };
 use nu_table::{StyledString, TextStyle, Theme};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -66,25 +66,14 @@ impl Command for Table {
             PipelineData::Value(Value::Binary { val, .. }, ..) => Ok(PipelineData::RawStream(
                 RawStream::new(
                     Box::new(
-                        vec![Ok(
-                            if val.iter().all(|x| {
-                                *x < 128
-                                    && (*x >= b' ' || *x == b'\t' || *x == b'\r' || *x == b'\n')
-                            }) {
-                                format!("{}", String::from_utf8_lossy(&val))
-                                    .as_bytes()
-                                    .to_vec()
-                            } else {
-                                format!("{}\n", nu_pretty_hex::pretty_hex(&val))
-                                    .as_bytes()
-                                    .to_vec()
-                            },
-                        )]
+                        vec![Ok(format!("{}\n", nu_pretty_hex::pretty_hex(&val))
+                            .as_bytes()
+                            .to_vec())]
                         .into_iter(),
                     ),
                     ctrlc,
                 ),
-                call.head,
+                head,
                 None,
             )),
             PipelineData::Value(Value::List { vals, .. }, ..) => {

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -5,8 +5,8 @@ use nu_engine::{env_to_string, CallExt};
 use nu_protocol::ast::{Call, PathMember};
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Config, DataSource, IntoPipelineData, PipelineData, PipelineMetadata, ShellError,
-    Signature, Span, StringStream, SyntaxShape, Value, ValueStream,
+    Category, Config, DataSource, IntoPipelineData, ListStream, PipelineData, PipelineMetadata,
+    RawStream, ShellError, Signature, Span, StringStream, SyntaxShape, Value,
 };
 use nu_table::{StyledString, TextStyle, Theme};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -62,35 +62,29 @@ impl Command for Table {
         };
 
         match input {
-            PipelineData::ByteStream(stream, ..) => Ok(PipelineData::StringStream(
-                StringStream::from_stream(
-                    stream.map(move |x| {
-                        Ok(if x.iter().all(|x| x.is_ascii()) {
-                            format!("{}", String::from_utf8_lossy(&x?))
-                        } else {
-                            format!("{}\n", nu_pretty_hex::pretty_hex(&x?))
-                        })
-                    }),
+            PipelineData::RawStream(..) => Ok(input),
+            PipelineData::Value(Value::Binary { val, .. }, ..) => Ok(PipelineData::RawStream(
+                RawStream::new(
+                    Box::new(
+                        vec![Ok(
+                            if val.iter().all(|x| {
+                                *x < 128
+                                    && (*x >= b' ' || *x == b'\t' || *x == b'\r' || *x == b'\n')
+                            }) {
+                                format!("{}", String::from_utf8_lossy(&val))
+                                    .as_bytes()
+                                    .to_vec()
+                            } else {
+                                format!("{}\n", nu_pretty_hex::pretty_hex(&val))
+                                    .as_bytes()
+                                    .to_vec()
+                            },
+                        )]
+                        .into_iter(),
+                    ),
                     ctrlc,
                 ),
-                head,
-                None,
-            )),
-            PipelineData::Value(Value::Binary { val, .. }, ..) => Ok(PipelineData::StringStream(
-                StringStream::from_stream(
-                    vec![Ok(
-                        if val.iter().all(|x| {
-                            *x < 128 && (*x >= b' ' || *x == b'\t' || *x == b'\r' || *x == b'\n')
-                        }) {
-                            format!("{}", String::from_utf8_lossy(&val))
-                        } else {
-                            format!("{}\n", nu_pretty_hex::pretty_hex(&val))
-                        },
-                    )]
-                    .into_iter(),
-                    ctrlc,
-                ),
-                head,
+                call.head,
                 None,
             )),
             PipelineData::Value(Value::List { vals, .. }, ..) => {
@@ -127,7 +121,7 @@ impl Command for Table {
                             None => LsColors::default(),
                         };
 
-                        ValueStream::from_stream(
+                        ListStream::from_stream(
                             stream.map(move |mut x| match &mut x {
                                 Value::Record { cols, vals, .. } => {
                                     let mut idx = 0;
@@ -194,15 +188,15 @@ impl Command for Table {
 
                 let head = call.head;
 
-                Ok(PipelineData::StringStream(
-                    StringStream::from_stream(
-                        PagingTableCreator {
+                Ok(PipelineData::RawStream(
+                    RawStream::new(
+                        Box::new(PagingTableCreator {
                             row_offset,
                             config,
                             ctrlc: ctrlc.clone(),
                             head,
                             stream,
-                        },
+                        }),
                         ctrlc,
                     ),
                     head,
@@ -381,14 +375,14 @@ fn convert_with_precision(val: &str, precision: usize) -> Result<String, ShellEr
 
 struct PagingTableCreator {
     head: Span,
-    stream: ValueStream,
+    stream: ListStream,
     ctrlc: Option<Arc<AtomicBool>>,
     config: Config,
     row_offset: usize,
 }
 
 impl Iterator for PagingTableCreator {
-    type Item = Result<String, ShellError>;
+    type Item = Result<Vec<u8>, ShellError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let mut batch = vec![];
@@ -443,7 +437,7 @@ impl Iterator for PagingTableCreator {
             Ok(Some(table)) => {
                 let result = nu_table::draw_table(&table, term_width, &color_hm, &self.config);
 
-                Some(Ok(result))
+                Some(Ok(result.as_bytes().to_vec()))
             }
             Err(err) => Some(Err(err)),
             _ => None,

--- a/crates/nu-plugin/src/plugin/declaration.rs
+++ b/crates/nu-plugin/src/plugin/declaration.rs
@@ -6,7 +6,7 @@ use std::io::BufReader;
 use std::path::{Path, PathBuf};
 
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{ast::Call, Signature, Value};
+use nu_protocol::{ast::Call, Signature};
 use nu_protocol::{PipelineData, ShellError};
 
 #[derive(Clone)]

--- a/crates/nu-plugin/src/plugin/declaration.rs
+++ b/crates/nu-plugin/src/plugin/declaration.rs
@@ -70,33 +70,7 @@ impl Command for PluginDeclaration {
             )
         })?;
 
-        let input = match input {
-            PipelineData::Value(value, ..) => value,
-            PipelineData::ListStream(stream, ..) => {
-                let values = stream.collect::<Vec<Value>>();
-
-                Value::List {
-                    vals: values,
-                    span: call.head,
-                }
-            }
-            PipelineData::StringStream(stream, ..) => {
-                let val = stream.into_string("")?;
-
-                Value::String {
-                    val,
-                    span: call.head,
-                }
-            }
-            PipelineData::ByteStream(stream, ..) => {
-                let val = stream.into_vec()?;
-
-                Value::Binary {
-                    val,
-                    span: call.head,
-                }
-            }
-        };
+        let input = input.into_value(call.head);
 
         // Create message to plugin to indicate that signature is required and
         // send call to plugin asking for signature

--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -1,7 +1,8 @@
 use std::sync::{atomic::AtomicBool, Arc};
 
 use crate::{
-    ast::PathMember, ByteStream, Config, ShellError, Span, StringStream, Value, ValueStream,
+    ast::PathMember, ByteStream, Config, ListStream, RawStream, ShellError, Span, StringStream,
+    Value,
 };
 
 /// The foundational abstraction for input and output to commands
@@ -36,9 +37,10 @@ use crate::{
 #[derive(Debug)]
 pub enum PipelineData {
     Value(Value, Option<PipelineMetadata>),
-    ListStream(ValueStream, Option<PipelineMetadata>),
-    StringStream(StringStream, Span, Option<PipelineMetadata>),
-    ByteStream(ByteStream, Span, Option<PipelineMetadata>),
+    ListStream(ListStream, Option<PipelineMetadata>),
+    // StringStream(StringStream, Span, Option<PipelineMetadata>),
+    // ByteStream(ByteStream, Span, Option<PipelineMetadata>),
+    RawStream(RawStream, Span, Option<PipelineMetadata>),
 }
 
 #[derive(Debug, Clone)]
@@ -63,8 +65,9 @@ impl PipelineData {
     pub fn metadata(&self) -> Option<PipelineMetadata> {
         match self {
             PipelineData::ListStream(_, x) => x.clone(),
-            PipelineData::ByteStream(_, _, x) => x.clone(),
-            PipelineData::StringStream(_, _, x) => x.clone(),
+            // PipelineData::ByteStream(_, _, x) => x.clone(),
+            // PipelineData::StringStream(_, _, x) => x.clone(),
+            PipelineData::RawStream(_, _, x) => x.clone(),
             PipelineData::Value(_, x) => x.clone(),
         }
     }
@@ -72,8 +75,9 @@ impl PipelineData {
     pub fn set_metadata(mut self, metadata: Option<PipelineMetadata>) -> Self {
         match &mut self {
             PipelineData::ListStream(_, x) => *x = metadata,
-            PipelineData::ByteStream(_, _, x) => *x = metadata,
-            PipelineData::StringStream(_, _, x) => *x = metadata,
+            // PipelineData::ByteStream(_, _, x) => *x = metadata,
+            // PipelineData::StringStream(_, _, x) => *x = metadata,
+            PipelineData::RawStream(_, _, x) => *x = metadata,
             PipelineData::Value(_, x) => *x = metadata,
         }
 
@@ -88,33 +92,51 @@ impl PipelineData {
                 vals: s.collect(),
                 span, // FIXME?
             },
-            PipelineData::StringStream(s, ..) => {
-                let mut output = String::new();
+            PipelineData::RawStream(mut s, ..) => {
+                let mut items = vec![];
 
-                for item in s {
-                    match item {
-                        Ok(s) => output.push_str(&s),
-                        Err(err) => return Value::Error { error: err },
-                    }
-                }
-                Value::String {
-                    val: output,
-                    span, // FIXME?
-                }
-            }
-            PipelineData::ByteStream(s, ..) => {
-                let mut output = vec![];
-
-                for item in s {
-                    match item {
-                        Ok(s) => output.extend(&s),
-                        Err(err) => return Value::Error { error: err },
+                for val in &mut s {
+                    match val {
+                        Ok(val) => {
+                            items.push(val);
+                        }
+                        Err(e) => {
+                            return Value::Error { error: e };
+                        }
                     }
                 }
 
-                Value::Binary {
-                    val: output,
-                    span, // FIXME?
+                if s.is_binary {
+                    let mut output = vec![];
+                    for item in items {
+                        match item.as_binary() {
+                            Ok(item) => {
+                                output.extend(item);
+                            }
+                            Err(err) => {
+                                return Value::Error { error: err };
+                            }
+                        }
+                    }
+
+                    Value::Binary {
+                        val: output,
+                        span, // FIXME?
+                    }
+                } else {
+                    let mut output = String::new();
+                    for item in items {
+                        match item.as_string() {
+                            Ok(s) => output.push_str(&s),
+                            Err(err) => {
+                                return Value::Error { error: err };
+                            }
+                        }
+                    }
+                    Value::String {
+                        val: output,
+                        span, // FIXME?
+                    }
                 }
             }
         }
@@ -134,9 +156,34 @@ impl PipelineData {
         match self {
             PipelineData::Value(v, ..) => Ok(v.into_string(separator, config)),
             PipelineData::ListStream(s, ..) => Ok(s.into_string(separator, config)),
-            PipelineData::StringStream(s, ..) => s.into_string(separator),
-            PipelineData::ByteStream(s, ..) => {
-                Ok(String::from_utf8_lossy(&s.into_vec()?).to_string())
+            // PipelineData::StringStream(s, ..) => s.into_string(separator),
+            // PipelineData::ByteStream(s, ..) => {
+            //     Ok(String::from_utf8_lossy(&s.into_vec()?).to_string())
+            // }
+            PipelineData::RawStream(s, ..) => {
+                let mut items = vec![];
+
+                for val in s {
+                    match val {
+                        Ok(val) => {
+                            items.push(val);
+                        }
+                        Err(e) => {
+                            return Err(e);
+                        }
+                    }
+                }
+
+                let mut output = String::new();
+                for item in items {
+                    match item.as_string() {
+                        Ok(s) => output.push_str(&s),
+                        Err(err) => {
+                            return Err(err);
+                        }
+                    }
+                }
+                Ok(output)
             }
         }
     }
@@ -191,9 +238,15 @@ impl PipelineData {
                 Ok(vals.into_iter().map(f).into_pipeline_data(ctrlc))
             }
             PipelineData::ListStream(stream, ..) => Ok(stream.map(f).into_pipeline_data(ctrlc)),
-            PipelineData::StringStream(stream, span, ..) => Ok(stream
+            // PipelineData::StringStream(stream, span, ..) => Ok(stream
+            //     .map(move |x| match x {
+            //         Ok(s) => f(Value::String { val: s, span }),
+            //         Err(err) => Value::Error { error: err },
+            //     })
+            //     .into_pipeline_data(ctrlc)),
+            PipelineData::RawStream(stream, span, ..) => Ok(stream
                 .map(move |x| match x {
-                    Ok(s) => f(Value::String { val: s, span }),
+                    Ok(v) => f(v),
                     Err(err) => Value::Error { error: err },
                 })
                 .into_pipeline_data(ctrlc)),
@@ -205,11 +258,11 @@ impl PipelineData {
                 Value::Error { error } => Err(error),
                 v => Ok(v.into_pipeline_data()),
             },
-            PipelineData::ByteStream(_, span, ..) => Err(ShellError::UnsupportedInput(
-                "Binary output from this command may need to be decoded using the 'decode' command"
-                    .into(),
-                span,
-            )),
+            // PipelineData::ByteStream(_, span, ..) => Err(ShellError::UnsupportedInput(
+            //     "Binary output from this command may need to be decoded using the 'decode' command"
+            //         .into(),
+            //     span,
+            // )),
         }
     }
 
@@ -232,24 +285,32 @@ impl PipelineData {
             PipelineData::ListStream(stream, ..) => {
                 Ok(stream.map(f).flatten().into_pipeline_data(ctrlc))
             }
-            PipelineData::StringStream(stream, span, ..) => Ok(stream
+            PipelineData::RawStream(stream, ..) => Ok(stream
                 .map(move |x| match x {
-                    Ok(s) => Value::String { val: s, span },
+                    Ok(v) => v,
                     Err(err) => Value::Error { error: err },
                 })
                 .map(f)
                 .flatten()
                 .into_pipeline_data(ctrlc)),
+            // PipelineData::StringStream(stream, span, ..) => Ok(stream
+            //     .map(move |x| match x {
+            //         Ok(s) => Value::String { val: s, span },
+            //         Err(err) => Value::Error { error: err },
+            //     })
+            //     .map(f)
+            //     .flatten()
+            //     .into_pipeline_data(ctrlc)),
             PipelineData::Value(Value::Range { val, .. }, ..) => match val.into_range_iter() {
                 Ok(iter) => Ok(iter.map(f).flatten().into_pipeline_data(ctrlc)),
                 Err(error) => Err(error),
             },
             PipelineData::Value(v, ..) => Ok(f(v).into_iter().into_pipeline_data(ctrlc)),
-            PipelineData::ByteStream(_, span, ..) => Err(ShellError::UnsupportedInput(
-                "Binary output from this command may need to be decoded using the 'decode' command"
-                    .into(),
-                span,
-            )),
+            // PipelineData::ByteStream(_, span, ..) => Err(ShellError::UnsupportedInput(
+            //     "Binary output from this command may need to be decoded using the 'decode' command"
+            //         .into(),
+            //     span,
+            // )),
         }
     }
 
@@ -267,14 +328,21 @@ impl PipelineData {
                 Ok(vals.into_iter().filter(f).into_pipeline_data(ctrlc))
             }
             PipelineData::ListStream(stream, ..) => Ok(stream.filter(f).into_pipeline_data(ctrlc)),
-            PipelineData::StringStream(stream, span, ..) => Ok(stream
+            // PipelineData::StringStream(stream, span, ..) => Ok(stream
+            //     .map(move |x| match x {
+            //         Ok(s) => Value::String { val: s, span },
+            //         Err(err) => Value::Error { error: err },
+            //     })
+            //     .filter(f)
+            //     .into_pipeline_data(ctrlc)),
+
+            PipelineData::RawStream(stream, ..) => Ok(stream
                 .map(move |x| match x {
-                    Ok(s) => Value::String { val: s, span },
+                    Ok(v) => v,
                     Err(err) => Value::Error { error: err },
                 })
                 .filter(f)
                 .into_pipeline_data(ctrlc)),
-
             PipelineData::Value(Value::Range { val, .. }, ..) => {
                 Ok(val.into_range_iter()?.filter(f).into_pipeline_data(ctrlc))
             }
@@ -285,11 +353,11 @@ impl PipelineData {
                     Ok(Value::Nothing { span: v.span()? }.into_pipeline_data())
                 }
             }
-            PipelineData::ByteStream(_, span, ..) => Err(ShellError::UnsupportedInput(
-                "Binary output from this command may need to be decoded using the 'decode' command"
-                    .into(),
-                span,
-            )),
+            // PipelineData::ByteStream(_, span, ..) => Err(ShellError::UnsupportedInput(
+            //     "Binary output from this command may need to be decoded using the 'decode' command"
+            //         .into(),
+            //     span,
+            // )),
         }
     }
 }
@@ -305,7 +373,7 @@ impl IntoIterator for PipelineData {
         match self {
             PipelineData::Value(Value::List { vals, .. }, metadata) => {
                 PipelineIterator(PipelineData::ListStream(
-                    ValueStream {
+                    ListStream {
                         stream: Box::new(vals.into_iter()),
                         ctrlc: None,
                     },
@@ -315,14 +383,14 @@ impl IntoIterator for PipelineData {
             PipelineData::Value(Value::Range { val, .. }, metadata) => {
                 match val.into_range_iter() {
                     Ok(iter) => PipelineIterator(PipelineData::ListStream(
-                        ValueStream {
+                        ListStream {
                             stream: Box::new(iter),
                             ctrlc: None,
                         },
                         metadata,
                     )),
                     Err(error) => PipelineIterator(PipelineData::ListStream(
-                        ValueStream {
+                        ListStream {
                             stream: Box::new(std::iter::once(Value::Error { error })),
                             ctrlc: None,
                         },
@@ -343,20 +411,24 @@ impl Iterator for PipelineIterator {
             PipelineData::Value(Value::Nothing { .. }, ..) => None,
             PipelineData::Value(v, ..) => Some(std::mem::take(v)),
             PipelineData::ListStream(stream, ..) => stream.next(),
-            PipelineData::StringStream(stream, span, ..) => stream.next().map(|x| match x {
-                Ok(x) => Value::String {
-                    val: x,
-                    span: *span,
-                },
+            PipelineData::RawStream(stream, ..) => stream.next().map(|x| match x {
+                Ok(x) => x,
                 Err(err) => Value::Error { error: err },
             }),
-            PipelineData::ByteStream(stream, span, ..) => stream.next().map(|x| match x {
-                Ok(x) => Value::Binary {
-                    val: x,
-                    span: *span,
-                },
-                Err(err) => Value::Error { error: err },
-            }),
+            // PipelineData::StringStream(stream, span, ..) => stream.next().map(|x| match x {
+            //     Ok(x) => Value::String {
+            //         val: x,
+            //         span: *span,
+            //     },
+            //     Err(err) => Value::Error { error: err },
+            // }),
+            // PipelineData::ByteStream(stream, span, ..) => stream.next().map(|x| match x {
+            //     Ok(x) => Value::Binary {
+            //         val: x,
+            //         span: *span,
+            //     },
+            //     Err(err) => Value::Error { error: err },
+            // }),
         }
     }
 }
@@ -391,7 +463,7 @@ where
 {
     fn into_pipeline_data(self, ctrlc: Option<Arc<AtomicBool>>) -> PipelineData {
         PipelineData::ListStream(
-            ValueStream {
+            ListStream {
                 stream: Box::new(self.into_iter().map(Into::into)),
                 ctrlc,
             },
@@ -405,7 +477,7 @@ where
         ctrlc: Option<Arc<AtomicBool>>,
     ) -> PipelineData {
         PipelineData::ListStream(
-            ValueStream {
+            ListStream {
                 stream: Box::new(self.into_iter().map(Into::into)),
                 ctrlc,
             },

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -239,6 +239,18 @@ impl Value {
         }
     }
 
+    pub fn as_binary(&self) -> Result<&[u8], ShellError> {
+        match self {
+            Value::Binary { val, .. } => Ok(val),
+            Value::String { val, .. } => Ok(val.as_bytes()),
+            x => Err(ShellError::CantConvert(
+                "binary".into(),
+                x.get_type().to_string(),
+                self.span()?,
+            )),
+        }
+    }
+
     pub fn as_record(&self) -> Result<(&[String], &[Value]), ShellError> {
         match self {
             Value::Record { cols, vals, .. } => Ok((cols, vals)),

--- a/crates/nu-protocol/src/value/stream.rs
+++ b/crates/nu-protocol/src/value/stream.rs
@@ -45,6 +45,133 @@ impl Iterator for ByteStream {
     }
 }
 
+pub struct RawStream {
+    pub stream: Box<dyn Iterator<Item = Result<Vec<u8>, ShellError>> + Send + 'static>,
+    pub leftover: Vec<u8>,
+    pub ctrlc: Option<Arc<AtomicBool>>,
+    pub is_binary: bool,
+    pub span: Span,
+}
+
+impl RawStream {
+    pub fn new(
+        stream: Box<dyn Iterator<Item = Result<Vec<u8>, ShellError>> + Send + 'static>,
+        ctrlc: Option<Arc<AtomicBool>>,
+    ) -> Self {
+        Self {
+            stream,
+            leftover: vec![],
+            ctrlc,
+            is_binary: false,
+            span: Span::new(0, 0),
+        }
+    }
+
+    pub fn into_bytes(self) -> Result<Vec<u8>, ShellError> {
+        let mut output = vec![];
+
+        for item in self.stream {
+            output.extend(item?);
+        }
+
+        Ok(output)
+    }
+}
+impl Debug for RawStream {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RawStream").finish()
+    }
+}
+impl Iterator for RawStream {
+    type Item = Result<Value, ShellError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // If we know we're already binary, just output that
+        if self.is_binary {
+            match self.stream.next() {
+                Some(buffer) => match buffer {
+                    Ok(mut v) => {
+                        while let Some(b) = self.leftover.pop() {
+                            v.insert(0, b);
+                        }
+                        Some(Ok(Value::Binary {
+                            val: v,
+                            span: self.span,
+                        }))
+                    }
+                    Err(e) => Some(Err(e)),
+                },
+                None => None,
+            }
+        } else {
+            // We *may* be text. We're only going to try utf-8. Other decodings
+            // needs to be taken as binary first, then passed through `decode`.
+            match self.stream.next() {
+                Some(buffer) => match buffer {
+                    Ok(mut v) => {
+                        while let Some(b) = self.leftover.pop() {
+                            v.insert(0, b);
+                        }
+
+                        match String::from_utf8(v.clone()) {
+                            Ok(s) => {
+                                // Great, we have a complete string, let's output it
+                                Some(Ok(Value::String {
+                                    val: s,
+                                    span: self.span,
+                                }))
+                            }
+                            Err(err) => {
+                                // Okay, we *might* have a string but we've also got some errors
+                                if v.is_empty() {
+                                    // We can just end here
+                                    None
+                                } else if v.len() > 3
+                                    && (v.len() - err.utf8_error().valid_up_to() > 3)
+                                {
+                                    // As UTF-8 characters are max 4 bytes, if we have more than that in error we know
+                                    // that it's not just a character spanning two frames.
+                                    // We now know we are definitely binary, so switch to binary and stay there.
+                                    self.is_binary = true;
+                                    Some(Ok(Value::Binary {
+                                        val: v,
+                                        span: self.span,
+                                    }))
+                                } else {
+                                    // Okay, we have a tiny bit of error at the end of the buffer. This could very well be
+                                    // a character that spans two frames. Since this is the case, remove the error from
+                                    // the current frame an dput it in the leftover buffer.
+                                    self.leftover =
+                                        v[(err.utf8_error().valid_up_to() + 1)..].to_vec();
+
+                                    let buf = v[0..err.utf8_error().valid_up_to()].to_vec();
+
+                                    match String::from_utf8(buf) {
+                                        Ok(s) => Some(Ok(Value::String {
+                                            val: s,
+                                            span: self.span,
+                                        })),
+                                        Err(_) => {
+                                            // Something is definitely wrong. Switch to binary, and stay there
+                                            self.is_binary = true;
+                                            Some(Ok(Value::Binary {
+                                                val: v,
+                                                span: self.span,
+                                            }))
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Err(e) => Some(Err(e)),
+                },
+                None => None,
+            }
+        }
+    }
+}
+
 /// A single string streamed over multiple parts. Optionally contains ctrl-c that can be used
 /// to break the stream.
 pub struct StringStream {
@@ -106,12 +233,12 @@ impl Iterator for StringStream {
 /// In practice, a "stream" here means anything which can be iterated and produce Values as it iterates.
 /// Like other iterators in Rust, observing values from this stream will drain the items as you view them
 /// and the stream cannot be replayed.
-pub struct ValueStream {
+pub struct ListStream {
     pub stream: Box<dyn Iterator<Item = Value> + Send + 'static>,
     pub ctrlc: Option<Arc<AtomicBool>>,
 }
 
-impl ValueStream {
+impl ListStream {
     pub fn into_string(self, separator: &str, config: &Config) -> String {
         self.map(|x: Value| x.into_string(", ", config))
             .collect::<Vec<String>>()
@@ -121,21 +248,21 @@ impl ValueStream {
     pub fn from_stream(
         input: impl Iterator<Item = Value> + Send + 'static,
         ctrlc: Option<Arc<AtomicBool>>,
-    ) -> ValueStream {
-        ValueStream {
+    ) -> ListStream {
+        ListStream {
             stream: Box::new(input),
             ctrlc,
         }
     }
 }
 
-impl Debug for ValueStream {
+impl Debug for ListStream {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ValueStream").finish()
     }
 }
 
-impl Iterator for ValueStream {
+impl Iterator for ListStream {
     type Item = Value;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/crates/nu-protocol/src/value/stream.rs
+++ b/crates/nu-protocol/src/value/stream.rs
@@ -7,44 +7,6 @@ use std::{
     },
 };
 
-/// A single buffer of binary data streamed over multiple parts. Optionally contains ctrl-c that can be used
-/// to break the stream.
-pub struct ByteStream {
-    pub stream: Box<dyn Iterator<Item = Result<Vec<u8>, ShellError>> + Send + 'static>,
-    pub ctrlc: Option<Arc<AtomicBool>>,
-}
-impl ByteStream {
-    pub fn into_vec(self) -> Result<Vec<u8>, ShellError> {
-        let mut output = vec![];
-        for item in self.stream {
-            output.append(&mut item?);
-        }
-
-        Ok(output)
-    }
-}
-impl Debug for ByteStream {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ByteStream").finish()
-    }
-}
-
-impl Iterator for ByteStream {
-    type Item = Result<Vec<u8>, ShellError>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if let Some(ctrlc) = &self.ctrlc {
-            if ctrlc.load(Ordering::SeqCst) {
-                None
-            } else {
-                self.stream.next()
-            }
-        } else {
-            self.stream.next()
-        }
-    }
-}
-
 pub struct RawStream {
     pub stream: Box<dyn Iterator<Item = Result<Vec<u8>, ShellError>> + Send + 'static>,
     pub leftover: Vec<u8>,
@@ -72,6 +34,16 @@ impl RawStream {
 
         for item in self.stream {
             output.extend(item?);
+        }
+
+        Ok(output)
+    }
+
+    pub fn into_string(self) -> Result<String, ShellError> {
+        let mut output = String::new();
+
+        for item in self {
+            output.push_str(&item?.as_string()?);
         }
 
         Ok(output)
@@ -168,61 +140,6 @@ impl Iterator for RawStream {
                 },
                 None => None,
             }
-        }
-    }
-}
-
-/// A single string streamed over multiple parts. Optionally contains ctrl-c that can be used
-/// to break the stream.
-pub struct StringStream {
-    pub stream: Box<dyn Iterator<Item = Result<String, ShellError>> + Send + 'static>,
-    pub ctrlc: Option<Arc<AtomicBool>>,
-}
-impl StringStream {
-    pub fn into_string(self, separator: &str) -> Result<String, ShellError> {
-        let mut output = String::new();
-
-        let mut first = true;
-        for s in self.stream {
-            output.push_str(&s?);
-
-            if !first {
-                output.push_str(separator);
-            } else {
-                first = false;
-            }
-        }
-        Ok(output)
-    }
-
-    pub fn from_stream(
-        input: impl Iterator<Item = Result<String, ShellError>> + Send + 'static,
-        ctrlc: Option<Arc<AtomicBool>>,
-    ) -> StringStream {
-        StringStream {
-            stream: Box::new(input),
-            ctrlc,
-        }
-    }
-}
-impl Debug for StringStream {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("StringStream").finish()
-    }
-}
-
-impl Iterator for StringStream {
-    type Item = Result<String, ShellError>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if let Some(ctrlc) = &self.ctrlc {
-            if ctrlc.load(Ordering::SeqCst) {
-                None
-            } else {
-                self.stream.next()
-            }
-        } else {
-            self.stream.next()
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,8 +17,8 @@ use nu_parser::parse;
 use nu_protocol::{
     ast::{Call, Expr, Expression, Pipeline, Statement},
     engine::{Command, EngineState, Stack, StateWorkingSet},
-    ByteStream, Category, Example, IntoPipelineData, PipelineData, RawStream, ShellError,
-    Signature, Span, Spanned, SyntaxShape, Value, CONFIG_VARIABLE_ID,
+    Category, Example, IntoPipelineData, PipelineData, RawStream, ShellError, Signature, Span,
+    Spanned, SyntaxShape, Value, CONFIG_VARIABLE_ID,
 };
 use std::{
     io::BufReader,

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,8 +17,8 @@ use nu_parser::parse;
 use nu_protocol::{
     ast::{Call, Expr, Expression, Pipeline, Statement},
     engine::{Command, EngineState, Stack, StateWorkingSet},
-    ByteStream, Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Span,
-    Spanned, SyntaxShape, Value, CONFIG_VARIABLE_ID,
+    ByteStream, Category, Example, IntoPipelineData, PipelineData, RawStream, ShellError,
+    Signature, Span, Spanned, SyntaxShape, Value, CONFIG_VARIABLE_ID,
 };
 use std::{
     io::BufReader,
@@ -119,11 +119,8 @@ fn main() -> Result<()> {
                 let stdin = std::io::stdin();
                 let buf_reader = BufReader::new(stdin);
 
-                PipelineData::ByteStream(
-                    ByteStream {
-                        stream: Box::new(BufferedReader::new(buf_reader)),
-                        ctrlc: Some(ctrlc),
-                    },
+                PipelineData::RawStream(
+                    RawStream::new(Box::new(BufferedReader::new(buf_reader)), Some(ctrlc)),
                     redirect_stdin.span,
                     None,
                 )


### PR DESCRIPTION
# Description

This replaces `BinaryStream` and `StringStream` with a new `RawStream` that can be binary or string. If it encounters something that's definitely not text, it switches into binary-only mode and then emits only binary. It will also attempt to re-decode a frame if it finds that almost all of the frame (minus the last few bytes) is utf-8 compatible. For this case, it will keep some leftover bytes to use when decoding the next frame. This allows a character to span two frames.

The end result appears to work for the basic things I tried: 

- `starship prompt` no longer needs decoding by default
- using `into binary` will always convert to binary
- using `into string` will attempt the conversion to string, and will fail with an error if it can't
- `cat /dev/urandom | first 1000` still gives binary data
- `open Cargo.toml` automatically reads in an converts to structured data
- `cat flamegraph.svg | from xml` converts to structured data (note: my flamegraph.svg is many frames of raw data)

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
