### PR TITLE
Bump reedline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2863,7 +2863,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.2.0"
-source = "git+https://github.com/nushell/reedline?branch=main#d10a2e7bcb8f3bef2ca349617c19e9504a8e5117"
+source = "git+https://github.com/nushell/reedline?branch=main#998ddd545242d9eb2de066fabc7bf14d3e57a4d6"
 dependencies = [
  "chrono",
  "crossterm",


### PR DESCRIPTION
Should remove the need for manual `str find-replace -a (char newline) (char crlf)` in `PROMPT_COMMAND`

Fixes #575

# Description

(description of your pull request here)
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
