### PR TITLE
fixes process path being truncated

### DIFF
--- a/crates/nu-system/src/macos.rs
+++ b/crates/nu-system/src/macos.rs
@@ -303,12 +303,13 @@ impl ProcessInfo {
 
     /// Name of command
     pub fn name(&self) -> String {
-        self.command()
-            .split(' ')
-            .collect::<Vec<_>>()
-            .first()
-            .map(|x| x.to_string())
-            .unwrap_or_default()
+        // self.command()
+        //     .split(' ')
+        //     .collect::<Vec<_>>()
+        //     .first()
+        //     .map(|x| x.to_string())
+        //     .unwrap_or_default()
+        self.command_only()
     }
 
     /// Full name of command, with arguments
@@ -327,6 +328,19 @@ impl ProcessInfo {
                 cmd.pop();
                 cmd = cmd.replace("\n", " ").replace("\t", " ");
                 cmd
+            } else {
+                String::from("")
+            }
+        } else {
+            String::from("")
+        }
+    }
+
+    /// Full name of comand only
+    pub fn command_only(&self) -> String {
+        if let Some(path) = &self.curr_path {
+            if !path.cmd.is_empty() {
+                path.exe.to_string_lossy().to_string()
             } else {
                 String::from("")
             }


### PR DESCRIPTION
# Description

fixes #884
before:
<img width="988" alt="image" src="https://user-images.githubusercontent.com/343840/151664794-15a2dd06-d688-474a-9d34-ce983172235c.png">
after:
<img width="1550" alt="image" src="https://user-images.githubusercontent.com/343840/151664746-12f8b1ba-1a82-4f91-852b-08753495ae80.png">

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
