### PR TITLE
add help --find to help doc

### DIFF
--- a/crates/nu-command/src/core_commands/help.rs
+++ b/crates/nu-command/src/core_commands/help.rs
@@ -234,6 +234,7 @@ fn help(
 Here are some tips to help you get started.
   * help commands - list all available commands
   * help <command name> - display help about a particular command
+  * help --find <text to search> - search through all of help
 
 Nushell works on the idea of a "pipeline". Pipelines are commands connected with the '|' character.
 Each stage in the pipeline works together to load, parse, and display information to you.


### PR DESCRIPTION

This lets everyone know when they type the help command that

```rust
help --find <text to search>
```

is a very valuable way to search through all of help.
I can never remember this myself so I thought other users would
want to know about it too.

