### PR TITLE
Allow viewing the source code of blocks

### DIFF
--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -330,7 +330,7 @@ pub fn create_default_context(cwd: impl AsRef<Path>) -> EngineState {
 
         // Experimental
         bind_command! {
-            View,
+            ViewSource,
         };
 
         #[cfg(feature = "plugin")]

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -328,6 +328,11 @@ pub fn create_default_context(cwd: impl AsRef<Path>) -> EngineState {
             Base64,
         };
 
+        // Experimental
+        bind_command! {
+            View,
+        };
+
         #[cfg(feature = "plugin")]
         bind_command!(Register);
 

--- a/crates/nu-command/src/experimental/mod.rs
+++ b/crates/nu-command/src/experimental/mod.rs
@@ -1,9 +1,9 @@
 mod git;
 mod git_checkout;
 mod list_git_branches;
-mod view;
+mod view_source;
 
 pub use git::Git;
 pub use git_checkout::GitCheckout;
 pub use list_git_branches::ListGitBranches;
-pub use view::View;
+pub use view_source::ViewSource;

--- a/crates/nu-command/src/experimental/mod.rs
+++ b/crates/nu-command/src/experimental/mod.rs
@@ -1,7 +1,9 @@
 mod git;
 mod git_checkout;
 mod list_git_branches;
+mod view;
 
 pub use git::Git;
 pub use git_checkout::GitCheckout;
 pub use list_git_branches::ListGitBranches;
+pub use view::View;

--- a/crates/nu-command/src/experimental/view.rs
+++ b/crates/nu-command/src/experimental/view.rs
@@ -1,0 +1,112 @@
+use nu_engine::CallExt;
+use nu_protocol::ast::Call;
+use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::{
+    Category, IntoPipelineData, PipelineData, ShellError, Signature, SyntaxShape, Value,
+};
+
+#[derive(Clone)]
+pub struct View;
+
+impl Command for View {
+    fn name(&self) -> &str {
+        "view"
+    }
+
+    fn usage(&self) -> &str {
+        "View a block"
+    }
+
+    fn signature(&self) -> nu_protocol::Signature {
+        Signature::build("view")
+            .desc(self.usage())
+            .required("block", SyntaxShape::Any, "the block to view")
+            .category(Category::Core)
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        let arg: Value = call.req(engine_state, stack, 0)?;
+        let arg_span = arg.span()?;
+
+        match arg {
+            Value::Block { span, .. } => {
+                let contents = engine_state.get_span_contents(&span);
+                Ok(
+                    Value::string(String::from_utf8_lossy(contents), call.head)
+                        .into_pipeline_data(),
+                )
+            }
+            Value::String { val, .. } => {
+                if let Some(decl_id) = engine_state.find_decl(val.as_bytes()) {
+                    // arg is a command
+                    let decl = engine_state.get_decl(decl_id);
+                    if let Some(block_id) = decl.get_block_id() {
+                        let block = engine_state.get_block(block_id);
+                        if let Some(block_span) = block.span {
+                            let contents = engine_state.get_span_contents(&block_span);
+                            Ok(Value::string(String::from_utf8_lossy(contents), call.head)
+                                .into_pipeline_data())
+                        } else {
+                            Err(ShellError::SpannedLabeledError(
+                                "Cannot view value".to_string(),
+                                "the command does not have a viewable block".to_string(),
+                                arg_span,
+                            ))
+                        }
+                    } else {
+                        Err(ShellError::SpannedLabeledError(
+                            "Cannot view value".to_string(),
+                            "the command does not have a viewable block".to_string(),
+                            arg_span,
+                        ))
+                    }
+                } else if let Some(overlay_id) = engine_state.find_overlay(val.as_bytes()) {
+                    // arg is a module
+                    let overlay = engine_state.get_overlay(overlay_id);
+                    if let Some(overlay_span) = overlay.span {
+                        let contents = engine_state.get_span_contents(&overlay_span);
+                        Ok(Value::string(String::from_utf8_lossy(contents), call.head)
+                            .into_pipeline_data())
+                    } else {
+                        Err(ShellError::SpannedLabeledError(
+                            "Cannot view value".to_string(),
+                            "the module does not have a viewable block".to_string(),
+                            arg_span,
+                        ))
+                    }
+                } else {
+                    Err(ShellError::SpannedLabeledError(
+                        "Cannot view value".to_string(),
+                        "this name does not correspond to a viewable value".to_string(),
+                        arg_span,
+                    ))
+                }
+            }
+            _ => Err(ShellError::SpannedLabeledError(
+                "Cannot view value".to_string(),
+                "this value cannot be viewed".to_string(),
+                arg_span,
+            )),
+        }
+
+        // let mut stack = stack.captures_to_stack(&block.captures);
+        // let block = engine_state.get_block(block.block_id);
+
+        // if let Some(span) = block.span {
+        //     let contents = engine_state.get_span_contents(&span);
+        //     Ok(Value::string(String::from_utf8_lossy(contents), call.head).into_pipeline_data())
+        // } else {
+        //     Err(ShellError::SpannedLabeledError(
+        //         "Cannot view block".to_string(),
+        //         "block does not have any span".to_string(),
+        //         call.head,
+        //     ))
+        // }
+    }
+}

--- a/crates/nu-command/src/experimental/view.rs
+++ b/crates/nu-command/src/experimental/view.rs
@@ -14,13 +14,13 @@ impl Command for View {
     }
 
     fn usage(&self) -> &str {
-        "View a block"
+        "View a block, module, or a definition"
     }
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("view")
             .desc(self.usage())
-            .required("block", SyntaxShape::Any, "the block to view")
+            .required("item", SyntaxShape::Any, "name or block to view")
             .category(Category::Core)
     }
 
@@ -94,19 +94,5 @@ impl Command for View {
                 arg_span,
             )),
         }
-
-        // let mut stack = stack.captures_to_stack(&block.captures);
-        // let block = engine_state.get_block(block.block_id);
-
-        // if let Some(span) = block.span {
-        //     let contents = engine_state.get_span_contents(&span);
-        //     Ok(Value::string(String::from_utf8_lossy(contents), call.head).into_pipeline_data())
-        // } else {
-        //     Err(ShellError::SpannedLabeledError(
-        //         "Cannot view block".to_string(),
-        //         "block does not have any span".to_string(),
-        //         call.head,
-        //     ))
-        // }
     }
 }

--- a/crates/nu-command/src/experimental/view_source.rs
+++ b/crates/nu-command/src/experimental/view_source.rs
@@ -6,11 +6,11 @@ use nu_protocol::{
 };
 
 #[derive(Clone)]
-pub struct View;
+pub struct ViewSource;
 
-impl Command for View {
+impl Command for ViewSource {
     fn name(&self) -> &str {
-        "view"
+        "view-source"
     }
 
     fn usage(&self) -> &str {
@@ -18,7 +18,7 @@ impl Command for View {
     }
 
     fn signature(&self) -> nu_protocol::Signature {
-        Signature::build("view")
+        Signature::build("view-source")
             .desc(self.usage())
             .required("item", SyntaxShape::Any, "name or block to view")
             .category(Category::Core)

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -761,7 +761,7 @@ pub fn parse_module_block(
         }
     }
 
-    let mut overlay = Overlay::new();
+    let mut overlay = Overlay::from_span(span);
 
     let block: Block = output
         .block

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2956,6 +2956,7 @@ pub fn parse_block_expression(
     let captures = find_captures_in_block(working_set, &output, &mut seen, &mut seen_decls);
 
     output.captures = captures;
+    output.span = Some(span);
 
     working_set.exit_scope();
 

--- a/crates/nu-protocol/src/ast/block.rs
+++ b/crates/nu-protocol/src/ast/block.rs
@@ -1,6 +1,6 @@
 use std::ops::{Index, IndexMut};
 
-use crate::{Signature, VarId};
+use crate::{Signature, Span, VarId};
 
 use super::Statement;
 
@@ -10,6 +10,7 @@ pub struct Block {
     pub stmts: Vec<Statement>,
     pub captures: Vec<VarId>,
     pub redirect_env: bool,
+    pub span: Option<Span>, // None option encodes no span to avoid using test_span()
 }
 
 impl Block {
@@ -49,6 +50,7 @@ impl Block {
             stmts: vec![],
             captures: vec![],
             redirect_env: false,
+            span: None,
         }
     }
 }
@@ -63,6 +65,7 @@ where
             stmts: stmts.collect(),
             captures: vec![],
             redirect_env: false,
+            span: None,
         }
     }
 }

--- a/crates/nu-protocol/src/overlay.rs
+++ b/crates/nu-protocol/src/overlay.rs
@@ -1,4 +1,4 @@
-use crate::{BlockId, DeclId};
+use crate::{BlockId, DeclId, Span};
 
 use indexmap::IndexMap;
 
@@ -10,6 +10,7 @@ use indexmap::IndexMap;
 pub struct Overlay {
     pub decls: IndexMap<Vec<u8>, DeclId>,
     pub env_vars: IndexMap<Vec<u8>, BlockId>,
+    pub span: Option<Span>,
 }
 
 impl Overlay {
@@ -17,6 +18,15 @@ impl Overlay {
         Overlay {
             decls: IndexMap::new(),
             env_vars: IndexMap::new(),
+            span: None,
+        }
+    }
+
+    pub fn from_span(span: Span) -> Self {
+        Overlay {
+            decls: IndexMap::new(),
+            env_vars: IndexMap::new(),
+            span: Some(span),
         }
     }
 


### PR DESCRIPTION
# Description

## Features

This PR adds an experimental `view` command that lets you view the source code of:
* a block 
* a module
* a custom command

## Caveats

* Currently, viewing individual blocks of `export env` is not possible -- you need to view the whole module. However, viewing `export def` and `export def-env` is possible (e.g., using `view "module-name def-name").
* It shows only the block part. E.g., the `def name [args...]` parts will be lost.
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
