### PR TITLE
Ignore clippy's erroneous warnings

### DIFF
--- a/crates/nu-command/src/filters/lines.rs
+++ b/crates/nu-command/src/filters/lines.rs
@@ -101,6 +101,7 @@ impl Command for Lines {
 
                 let split_char = if s.contains("\r\n") { "\r\n" } else { "\n" };
 
+                #[allow(clippy::needless_collect)]
                 let lines = s
                     .split(split_char)
                     .map(|s| s.to_string())

--- a/crates/nu-command/src/strings/detect_columns.rs
+++ b/crates/nu-command/src/strings/detect_columns.rs
@@ -59,6 +59,7 @@ fn detect_columns(
     let config = stack.get_config()?;
     let input = input.collect_string("", &config)?;
 
+    #[allow(clippy::needless_collect)]
     let input: Vec<_> = input
         .lines()
         .skip(num_rows_to_skip.unwrap_or_default())


### PR DESCRIPTION
# Description

Silence the erroneous clippy warnings about collecting.

cc @stormasm who was asking about this
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
