### PR TITLE
Use 'table' during internal->external

### DIFF
--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -182,6 +182,19 @@ impl Stack {
         }
     }
 
+    pub fn update_config(&mut self, name: &str, value: Value) {
+        if let Some(Value::Record { cols, vals, .. }) = self.vars.get_mut(&CONFIG_VARIABLE_ID) {
+            for col_val in cols.iter().zip(vals.iter_mut()) {
+                if col_val.0 == name {
+                    *col_val.1 = value;
+                    return;
+                }
+            }
+            cols.push(name.to_string());
+            vals.push(value);
+        }
+    }
+
     pub fn print_stack(&self) {
         println!("vars:");
         for (var, val) in &self.vars {

--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -178,10 +178,7 @@ impl Stack {
 
         match config {
             Ok(config) => config.into_config(),
-            Err(e) => {
-                println!("Can't find {} in {:?}", CONFIG_VARIABLE_ID, self);
-                Err(e)
-            }
+            Err(e) => Err(e),
         }
     }
 

--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -75,6 +75,10 @@ impl PipelineData {
         self
     }
 
+    pub fn is_nothing(&self) -> bool {
+        matches!(self, PipelineData::Value(Value::Nothing { .. }, ..))
+    }
+
     pub fn into_value(self, span: Span) -> Value {
         match self {
             PipelineData::Value(Value::Nothing { .. }, ..) => Value::nothing(span),


### PR DESCRIPTION
# Description

This switches from outputting debug text to translating structured data via `table` (without color) when sending between an internal command and an external command.

Things this allows you to do:

```
> ls | less
```
```
> ls | grep darren
│  6 │ darren.nu        │ file │     154 B │ 3 weeks ago  │
│ 13 │ source_darren.nu │ file │      50 B │ 2 weeks ago  │
```
And so on.

In short, it helps play a little nicer at the boundary if people just want to fall back onto their current toolset with what they're looking at on the screen.
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
