### PR TITLE
should be inclusive

### DIFF
--- a/crates/nu-command/src/date/format.rs
+++ b/crates/nu-command/src/date/format.rs
@@ -50,26 +50,17 @@ impl Command for SubCommand {
             Example {
                 description: "Format a given date using the given format string.",
                 example: "date format '%Y-%m-%d'",
-                result: Some(Value::String {
-                    val: Local::now().format("%Y-%m-%d").to_string(),
-                    span: Span::test_data(),
-                }),
+                result: None,
             },
             Example {
                 description: "Format a given date using the given format string.",
                 example: r#"date format "%Y-%m-%d %H:%M:%S""#,
-                result: Some(Value::String {
-                    val: Local::now().format("%Y-%m-%d %H:%M:%S").to_string(),
-                    span: Span::test_data(),
-                }),
+                result: None,
             },
             Example {
                 description: "Format a given date using the given format string.",
                 example: r#""2021-10-22 20:00:12 +01:00" | date format "%Y-%m-%d""#,
-                result: Some(Value::String {
-                    val: "2021-10-22".into(),
-                    span: Span::test_data(),
-                }),
+                result: None,
             },
         ]
     }

--- a/crates/nu-command/src/random/integer.rs
+++ b/crates/nu-command/src/random/integer.rs
@@ -84,7 +84,7 @@ fn integer(
         Some(Ordering::Equal) => Ok(PipelineData::Value(Value::Int { val: min, span }, None)),
         _ => {
             let mut thread_rng = thread_rng();
-            let result: i64 = thread_rng.gen_range(min..max);
+            let result: i64 = thread_rng.gen_range(min..=max);
 
             Ok(PipelineData::Value(Value::Int { val: result, span }, None))
         }


### PR DESCRIPTION
fixes #903 

# Description

`gen_range(min..max)` was supposed to be `gen_range(min..=max)`
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
