### PR TITLE
Update reedline to paste multiple command lines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3267,7 +3267,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.2.0"
-source = "git+https://github.com/nushell/reedline?branch=main#43788def682c5857ad7f453795d3e833a5f33a9c"
+source = "git+https://github.com/nushell/reedline?branch=main#375c779e360cd368bb75e583986eec856853bbf2"
 dependencies = [
  "chrono",
  "crossterm",

--- a/src/reedline_config.rs
+++ b/src/reedline_config.rs
@@ -344,9 +344,6 @@ fn parse_event(value: Value, config: &Config) -> Result<ReedlineEvent, ShellErro
 
                         ReedlineEvent::Edit(vec![edit])
                     }
-                    // TODO: add ReedlineEvent::Mouse
-                    // TODO: add ReedlineEvent::Resize
-                    // TODO: add ReedlineEvent::Paste
                     v => {
                         return Err(ShellError::UnsupportedConfigValue(
                             "Reedline event".to_string(),


### PR DESCRIPTION
# Changes to reedline since

- Pasting text containing multiple newline separated commands will now return each command (considered valid based on `Validator`) for evaluation and parse the paste after the next invocation of `Reedline::read_line`
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
