### PR TITLE
Add support for quick completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3277,7 +3277,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.2.0"
-source = "git+https://github.com/nushell/reedline?branch=main#375c779e360cd368bb75e583986eec856853bbf2"
+source = "git+https://github.com/nushell/reedline?branch=main#e4cec995262fc85fab3e08cad267e28a3da60460"
 dependencies = [
  "chrono",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
 
 [dependencies]
 reedline = { git = "https://github.com/nushell/reedline", branch = "main" }
+
 crossterm = "0.22.*"
 nu-cli = { path="./crates/nu-cli" }
 nu-command = { path="./crates/nu-command" }

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -15,5 +15,6 @@ nu-color-config = { path = "../nu-color-config" }
 miette = { version = "3.0.0", features = ["fancy"] }
 thiserror = "1.0.29"
 reedline = { git = "https://github.com/nushell/reedline", branch = "main" }
+
 log = "0.4"
 is_executable = "1.0.1"

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -59,6 +59,7 @@ pub struct Config {
     pub float_precision: i64,
     pub filesize_format: String,
     pub use_ansi_coloring: bool,
+    pub quick_completions: bool,
     pub env_conversions: HashMap<String, EnvConversion>,
     pub edit_mode: String,
     pub max_history_size: i64,
@@ -81,6 +82,7 @@ impl Default for Config {
             float_precision: 4,
             filesize_format: "auto".into(),
             use_ansi_coloring: true,
+            quick_completions: false,
             env_conversions: HashMap::new(), // TODO: Add default conversoins
             edit_mode: "emacs".into(),
             max_history_size: 1000,
@@ -183,6 +185,13 @@ impl Value {
                             config.use_ansi_coloring = b;
                         } else {
                             eprintln!("$config.use_ansi_coloring is not a bool")
+                        }
+                    }
+                    "quick_completions" => {
+                        if let Ok(b) = value.as_bool() {
+                            config.quick_completions = b;
+                        } else {
+                            eprintln!("$config.quick_completions is not a bool")
                         }
                     }
                     "filesize_format" => {

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -107,6 +107,7 @@ pub(crate) fn evaluate(engine_state: &mut EngineState) -> Result<()> {
                 engine_state: engine_state.clone(),
             }))
             .with_completer(Box::new(NuCompleter::new(engine_state.clone())))
+            .with_quick_completions(config.quick_completions)
             .with_ansi_colors(config.use_ansi_coloring);
 
         line_editor = add_completion_menu(line_editor, &config);


### PR DESCRIPTION
# Description

This adds support to enable (off by default) a completion mode that will auto-select the completion if you type and reach the point of having a single entry.

To configure this setting, use `$config.quick_completions`, a bool
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
