### PR TITLE
Simplify `describe`

### DIFF
--- a/crates/nu-command/src/core_commands/describe.rs
+++ b/crates/nu-command/src/core_commands/describe.rs
@@ -1,6 +1,8 @@
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, Value};
+use nu_protocol::{
+    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Value,
+};
 
 #[derive(Clone)]
 pub struct Describe;
@@ -20,7 +22,7 @@ impl Command for Describe {
 
     fn run(
         &self,
-        engine_state: &EngineState,
+        _engine_state: &EngineState,
         _stack: &mut Stack,
         call: &Call,
         input: PipelineData,
@@ -32,13 +34,12 @@ impl Command for Describe {
                 None,
             ))
         } else {
-            input.map(
-                move |x| Value::String {
-                    val: x.get_type().to_string(),
-                    span: head,
-                },
-                engine_state.ctrlc.clone(),
-            )
+            let value = input.into_value(call.head);
+            Ok(Value::String {
+                val: value.get_type().to_string(),
+                span: head,
+            }
+            .into_pipeline_data())
         }
     }
 


### PR DESCRIPTION
# Description

This will do a collect on the pipelinedata, converting it into a Value, before doing the describe step. This gives us a bit more useful info on the input.
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
