### PR TITLE
Allow let-env to be dynamic

### DIFF
--- a/crates/nu-command/src/env/let_env.rs
+++ b/crates/nu-command/src/env/let_env.rs
@@ -1,4 +1,4 @@
-use nu_engine::{current_dir, eval_expression_with_input};
+use nu_engine::{current_dir, eval_expression_with_input, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{Category, PipelineData, Signature, SyntaxShape, Value};
@@ -33,9 +33,7 @@ impl Command for LetEnv {
         call: &Call,
         input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
-        let env_var = call.positional[0]
-            .as_string()
-            .expect("internal error: missing variable");
+        let env_var = call.req(engine_state, stack, 0)?;
 
         let keyword_expr = call.positional[1]
             .as_keyword()

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -230,3 +230,8 @@ fn export_def_env() -> TestResult {
         "BAZ",
     )
 }
+
+#[test]
+fn dynamic_let_env() -> TestResult {
+    run_test(r#"let x = "FOO"; let-env $x = "BAZ"; $env.FOO"#, "BAZ")
+}


### PR DESCRIPTION
# Description

Fixes #935 
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
