### PR TITLE
Remove broken error make examples

### DIFF
--- a/crates/nu-command/src/core_commands/error_make.rs
+++ b/crates/nu-command/src/core_commands/error_make.rs
@@ -65,26 +65,14 @@ impl Command for ErrorMake {
     }
 
     fn examples(&self) -> Vec<Example> {
-        vec![
-            Example {
-                description: "Creates a labeled error",
-                example: r#"{msg: "The message" , label: {start: 0, end: 141, text: "Helpful message here"}} | error make"#,
-                result: None,
-            },
-            Example {
-                description: "Creates a labeled error, using a call argument",
-                example: r#"error make {msg: "The message" , label: {start: 0, end: 141, text: "Helpful message here"}}"#,
-                result: None,
-            },
-            Example {
-                description: "Create a custom error for a custom command",
-                example: r#"def foo [x] {
+        vec![Example {
+            description: "Create a custom error for a custom command",
+            example: r#"def foo [x] {
       let span = (metadata $x).span;
       error make {msg: "this is fishy", label: {text: "fish right here", start: $span.start, end: $span.end } } 
     }"#,
-                result: None,
-            },
-        ]
+            result: None,
+        }]
     }
 }
 


### PR DESCRIPTION
# Description

Remove broken `error make` examples. These were ported from nushell, but these spans need to be valid spans for this to work, and you can't create valid spans yourself (you need to use helpers like `metadata`).
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
