### PR TITLE
Switch more commands to redirecting blocks

### DIFF
--- a/crates/nu-command/src/core_commands/for_.rs
+++ b/crates/nu-command/src/core_commands/for_.rs
@@ -1,4 +1,4 @@
-use nu_engine::{eval_block, eval_expression, CallExt};
+use nu_engine::{eval_block_with_redirect, eval_expression, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{CaptureBlock, Command, EngineState, Stack};
 use nu_protocol::{
@@ -99,7 +99,12 @@ impl Command for For {
                     );
 
                     //let block = engine_state.get_block(block_id);
-                    match eval_block(&engine_state, &mut stack, &block, PipelineData::new(head)) {
+                    match eval_block_with_redirect(
+                        &engine_state,
+                        &mut stack,
+                        &block,
+                        PipelineData::new(head),
+                    ) {
                         Ok(pipeline_data) => pipeline_data.into_value(head),
                         Err(error) => Value::Error { error },
                     }
@@ -131,7 +136,12 @@ impl Command for For {
                     );
 
                     //let block = engine_state.get_block(block_id);
-                    match eval_block(&engine_state, &mut stack, &block, PipelineData::new(head)) {
+                    match eval_block_with_redirect(
+                        &engine_state,
+                        &mut stack,
+                        &block,
+                        PipelineData::new(head),
+                    ) {
                         Ok(pipeline_data) => pipeline_data.into_value(head),
                         Err(error) => Value::Error { error },
                     }
@@ -140,7 +150,7 @@ impl Command for For {
             x => {
                 stack.add_var(var_id, x);
 
-                eval_block(&engine_state, &mut stack, &block, PipelineData::new(head))
+                eval_block_with_redirect(&engine_state, &mut stack, &block, PipelineData::new(head))
             }
         }
     }

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -1,4 +1,4 @@
-use nu_engine::{eval_block, CallExt};
+use nu_engine::{eval_block_with_redirect, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{CaptureBlock, Command, EngineState, Stack};
 use nu_protocol::{
@@ -105,7 +105,12 @@ impl Command for Each {
                         }
                     }
 
-                    match eval_block(&engine_state, &mut stack, &block, PipelineData::new(span)) {
+                    match eval_block_with_redirect(
+                        &engine_state,
+                        &mut stack,
+                        &block,
+                        PipelineData::new(span),
+                    ) {
                         Ok(v) => v.into_value(span),
                         Err(error) => Value::Error { error },
                     }
@@ -145,7 +150,12 @@ impl Command for Each {
                         }
                     }
 
-                    match eval_block(&engine_state, &mut stack, &block, PipelineData::new(span)) {
+                    match eval_block_with_redirect(
+                        &engine_state,
+                        &mut stack,
+                        &block,
+                        PipelineData::new(span),
+                    ) {
                         Ok(v) => v.into_value(span),
                         Err(error) => Value::Error { error },
                     }
@@ -179,7 +189,12 @@ impl Command for Each {
                         }
                     }
 
-                    match eval_block(&engine_state, &mut stack, &block, PipelineData::new(span))? {
+                    match eval_block_with_redirect(
+                        &engine_state,
+                        &mut stack,
+                        &block,
+                        PipelineData::new(span),
+                    )? {
                         PipelineData::Value(
                             Value::Record {
                                 mut cols, mut vals, ..
@@ -213,7 +228,7 @@ impl Command for Each {
                     }
                 }
 
-                eval_block(&engine_state, &mut stack, &block, PipelineData::new(span))
+                eval_block_with_redirect(&engine_state, &mut stack, &block, PipelineData::new(span))
             }
         }
     }

--- a/crates/nu-command/src/filters/each_group.rs
+++ b/crates/nu-command/src/filters/each_group.rs
@@ -1,4 +1,4 @@
-use nu_engine::{eval_block, CallExt};
+use nu_engine::{eval_block_with_redirect, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{CaptureBlock, Command, EngineState, Stack};
 use nu_protocol::{
@@ -142,7 +142,7 @@ pub(crate) fn run_block_on_vec(
         }
     }
 
-    match eval_block(&engine_state, &mut stack, block, PipelineData::new(span)) {
+    match eval_block_with_redirect(&engine_state, &mut stack, block, PipelineData::new(span)) {
         Ok(pipeline) => pipeline,
         Err(error) => Value::Error { error }.into_pipeline_data(),
     }

--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -1,4 +1,4 @@
-use nu_engine::{eval_block, CallExt};
+use nu_engine::{eval_block_with_redirect, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{CaptureBlock, Command, EngineState, Stack};
 use nu_protocol::{
@@ -87,7 +87,12 @@ impl Command for ParEach {
                         }
                     }
 
-                    match eval_block(&engine_state, &mut stack, block, PipelineData::new(span)) {
+                    match eval_block_with_redirect(
+                        &engine_state,
+                        &mut stack,
+                        block,
+                        PipelineData::new(span),
+                    ) {
                         Ok(v) => v,
                         Err(error) => Value::Error { error }.into_pipeline_data(),
                     }
@@ -128,7 +133,12 @@ impl Command for ParEach {
                         }
                     }
 
-                    match eval_block(&engine_state, &mut stack, block, PipelineData::new(span)) {
+                    match eval_block_with_redirect(
+                        &engine_state,
+                        &mut stack,
+                        block,
+                        PipelineData::new(span),
+                    ) {
                         Ok(v) => v,
                         Err(error) => Value::Error { error }.into_pipeline_data(),
                     }
@@ -168,7 +178,12 @@ impl Command for ParEach {
                         }
                     }
 
-                    match eval_block(&engine_state, &mut stack, block, PipelineData::new(span)) {
+                    match eval_block_with_redirect(
+                        &engine_state,
+                        &mut stack,
+                        block,
+                        PipelineData::new(span),
+                    ) {
                         Ok(v) => v,
                         Err(error) => Value::Error { error }.into_pipeline_data(),
                     }
@@ -213,7 +228,12 @@ impl Command for ParEach {
                         }
                     }
 
-                    match eval_block(&engine_state, &mut stack, block, PipelineData::new(span)) {
+                    match eval_block_with_redirect(
+                        &engine_state,
+                        &mut stack,
+                        block,
+                        PipelineData::new(span),
+                    ) {
                         Ok(v) => v,
                         Err(error) => Value::Error { error }.into_pipeline_data(),
                     }
@@ -250,7 +270,12 @@ impl Command for ParEach {
                         }
                     }
 
-                    match eval_block(&engine_state, &mut stack, block, PipelineData::new(span))? {
+                    match eval_block_with_redirect(
+                        &engine_state,
+                        &mut stack,
+                        block,
+                        PipelineData::new(span),
+                    )? {
                         PipelineData::Value(
                             Value::Record {
                                 mut cols, mut vals, ..
@@ -284,7 +309,7 @@ impl Command for ParEach {
                     }
                 }
 
-                eval_block(&engine_state, &mut stack, block, PipelineData::new(span))
+                eval_block_with_redirect(&engine_state, &mut stack, block, PipelineData::new(span))
             }
         }
     }

--- a/crates/nu-command/src/filters/where_.rs
+++ b/crates/nu-command/src/filters/where_.rs
@@ -1,4 +1,4 @@
-use nu_engine::{eval_block, CallExt};
+use nu_engine::{eval_block_with_redirect, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{CaptureBlock, Command, EngineState, Stack};
 use nu_protocol::{Category, PipelineData, Signature, SyntaxShape};
@@ -47,8 +47,12 @@ impl Command for Where {
                             stack.add_var(*var_id, value.clone());
                         }
                     }
-                    let result =
-                        eval_block(&engine_state, &mut stack, &block, PipelineData::new(span));
+                    let result = eval_block_with_redirect(
+                        &engine_state,
+                        &mut stack,
+                        &block,
+                        PipelineData::new(span),
+                    );
 
                     match result {
                         Ok(result) => result.into_value(span).is_true(),

--- a/crates/nu-engine/src/lib.rs
+++ b/crates/nu-engine/src/lib.rs
@@ -10,6 +10,7 @@ pub use column::get_columns;
 pub use documentation::{generate_docs, get_brief_help, get_documentation, get_full_help};
 pub use env::*;
 pub use eval::{
-    eval_block, eval_expression, eval_expression_with_input, eval_operator, eval_subexpression,
+    eval_block, eval_block_with_redirect, eval_expression, eval_expression_with_input,
+    eval_operator, eval_subexpression,
 };
 pub use glob_from::glob_from;


### PR DESCRIPTION
# Description

This moves commands like `for`, `each`, `each group`, and `par-each` to use redirecting block evaluation, so that externals that end the block have their output redirected.
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
