### PR TITLE
Oops, match semantics of each group/window

### DIFF
--- a/crates/nu-command/src/filters/each_group.rs
+++ b/crates/nu-command/src/filters/each_group.rs
@@ -2,8 +2,8 @@ use nu_engine::{eval_block_with_redirect, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{CaptureBlock, Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData, Signature,
-    Span, Spanned, SyntaxShape, Value,
+    Category, Example, IntoInterruptiblePipelineData, PipelineData, Signature, Span, Spanned,
+    SyntaxShape, Value,
 };
 
 #[derive(Clone)]
@@ -73,7 +73,7 @@ impl Command for EachGroup {
             span: call.head,
         };
 
-        Ok(each_group_iterator.flatten().into_pipeline_data(ctrlc))
+        Ok(each_group_iterator.into_pipeline_data(ctrlc))
     }
 }
 
@@ -87,7 +87,7 @@ struct EachGroupIterator {
 }
 
 impl Iterator for EachGroupIterator {
-    type Item = PipelineData;
+    type Item = Value;
 
     fn next(&mut self) -> Option<Self::Item> {
         let mut group = vec![];
@@ -129,7 +129,7 @@ pub(crate) fn run_block_on_vec(
     engine_state: EngineState,
     stack: Stack,
     span: Span,
-) -> PipelineData {
+) -> Value {
     let value = Value::List { vals: input, span };
 
     let mut stack = stack.captures_to_stack(&capture_block.captures);
@@ -143,8 +143,8 @@ pub(crate) fn run_block_on_vec(
     }
 
     match eval_block_with_redirect(&engine_state, &mut stack, block, PipelineData::new(span)) {
-        Ok(pipeline) => pipeline,
-        Err(error) => Value::Error { error }.into_pipeline_data(),
+        Ok(pipeline) => pipeline.into_value(span),
+        Err(error) => Value::Error { error },
     }
 }
 

--- a/crates/nu-command/src/filters/each_window.rs
+++ b/crates/nu-command/src/filters/each_window.rs
@@ -2,8 +2,8 @@ use nu_engine::{eval_block_with_redirect, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{CaptureBlock, Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData, Signature,
-    Span, Spanned, SyntaxShape, Value,
+    Category, Example, IntoInterruptiblePipelineData, PipelineData, Signature, Span, Spanned,
+    SyntaxShape, Value,
 };
 
 #[derive(Clone)]
@@ -113,7 +113,7 @@ impl Command for EachWindow {
             stride,
         };
 
-        Ok(each_group_iterator.flatten().into_pipeline_data(ctrlc))
+        Ok(each_group_iterator.into_pipeline_data(ctrlc))
     }
 }
 
@@ -129,7 +129,7 @@ struct EachWindowIterator {
 }
 
 impl Iterator for EachWindowIterator {
-    type Item = PipelineData;
+    type Item = Value;
 
     fn next(&mut self) -> Option<Self::Item> {
         let mut group = self.previous.clone();
@@ -148,7 +148,7 @@ impl Iterator for EachWindowIterator {
                             break;
                         }
                     }
-                    None => break,
+                    None => return None,
                 }
             }
         } else {
@@ -166,7 +166,7 @@ impl Iterator for EachWindowIterator {
                             break;
                         }
                     }
-                    None => break,
+                    None => return None,
                 }
             }
 
@@ -197,7 +197,7 @@ pub(crate) fn run_block_on_vec(
     engine_state: EngineState,
     stack: Stack,
     span: Span,
-) -> PipelineData {
+) -> Value {
     let value = Value::List { vals: input, span };
 
     let mut stack = stack.captures_to_stack(&capture_block.captures);
@@ -211,8 +211,8 @@ pub(crate) fn run_block_on_vec(
     }
 
     match eval_block_with_redirect(&engine_state, &mut stack, block, PipelineData::new(span)) {
-        Ok(pipeline) => pipeline,
-        Err(error) => Value::Error { error }.into_pipeline_data(),
+        Ok(pipeline) => pipeline.into_value(span),
+        Err(error) => Value::Error { error },
     }
 }
 

--- a/crates/nu-command/src/filters/par_each_group.rs
+++ b/crates/nu-command/src/filters/par_each_group.rs
@@ -2,8 +2,8 @@ use nu_engine::{eval_block_with_redirect, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{CaptureBlock, Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData, Signature,
-    Spanned, SyntaxShape, Value,
+    Category, Example, IntoInterruptiblePipelineData, PipelineData, Signature, Spanned,
+    SyntaxShape, Value,
 };
 use rayon::prelude::*;
 
@@ -78,13 +78,12 @@ impl Command for ParEachGroup {
                     block,
                     PipelineData::new(span),
                 ) {
-                    Ok(v) => v,
-                    Err(error) => Value::Error { error }.into_pipeline_data(),
+                    Ok(v) => v.into_value(span),
+                    Err(error) => Value::Error { error },
                 }
             })
             .collect::<Vec<_>>()
             .into_iter()
-            .flatten()
             .into_pipeline_data(ctrlc))
     }
 }

--- a/crates/nu-command/tests/commands/each.rs
+++ b/crates/nu-command/tests/commands/each.rs
@@ -12,42 +12,36 @@ fn each_works_separately() {
     assert_eq!(actual.out, "[11,12,13]");
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn each_group_works() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
         r#"
-        echo [1 2 3 4 5 6] | each group 3 { $it } | to json
+        echo [1 2 3 4 5 6] | each group 3 { $it } | to json --raw
         "#
     ));
 
     assert_eq!(actual.out, "[[1,2,3],[4,5,6]]");
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn each_window() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
         r#"
-        echo [1 2 3 4] | each window 3 { $it } | to json
+        echo [1 2 3 4] | each window 3 { $it } | to json --raw
         "#
     ));
 
     assert_eq!(actual.out, "[[1,2,3],[2,3,4]]");
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn each_window_stride() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
         r#"
-        echo [1 2 3 4 5 6] | each window 3 -s 2 { echo $it } | to json
+        echo [1 2 3 4 5 6] | each window 3 -s 2 { echo $it } | to json --raw
         "#
     ));
 


### PR DESCRIPTION
# Description

Oops, made a couple mistakes in the semantics of `each group` and `each window`. Fixed. Enabled nushell tests.
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
