### PR TITLE
Make PipelineData helpers collect rawstreams

### DIFF
--- a/crates/nu-command/src/conversions/into/binary.rs
+++ b/crates/nu-command/src/conversions/into/binary.rs
@@ -103,7 +103,7 @@ fn into_binary(
             // TODO: in the future, we may want this to stream out, converting each to bytes
             let output = stream.into_bytes()?;
             Ok(Value::Binary {
-                val: output,
+                val: output.item,
                 span: head,
             }
             .into_pipeline_data())

--- a/crates/nu-command/src/conversions/into/string.rs
+++ b/crates/nu-command/src/conversions/into/string.rs
@@ -154,7 +154,7 @@ fn string_helper(
             // TODO: in the future, we may want this to stream out, converting each to bytes
             let output = stream.into_string()?;
             Ok(Value::String {
-                val: output,
+                val: output.item,
                 span: head,
             }
             .into_pipeline_data())

--- a/crates/nu-command/src/strings/decode.rs
+++ b/crates/nu-command/src/strings/decode.rs
@@ -45,7 +45,7 @@ impl Command for Decode {
 
         match input {
             PipelineData::RawStream(stream, ..) => {
-                let bytes: Vec<u8> = stream.into_bytes()?;
+                let bytes: Vec<u8> = stream.into_bytes()?.item;
 
                 let encoding = match Encoding::for_label(encoding.item.as_bytes()) {
                     None => Err(ShellError::SpannedLabeledError(

--- a/crates/nu-protocol/src/value/stream.rs
+++ b/crates/nu-protocol/src/value/stream.rs
@@ -30,24 +30,28 @@ impl RawStream {
         }
     }
 
-    pub fn into_bytes(self) -> Result<Vec<u8>, ShellError> {
+    pub fn into_bytes(self) -> Result<Spanned<Vec<u8>>, ShellError> {
         let mut output = vec![];
 
         for item in self.stream {
             output.extend(item?);
         }
 
-        Ok(output)
+        Ok(Spanned {
+            item: output,
+            span: self.span,
+        })
     }
 
-    pub fn into_string(self) -> Result<String, ShellError> {
+    pub fn into_string(self) -> Result<Spanned<String>, ShellError> {
         let mut output = String::new();
+        let span = self.span;
 
         for item in self {
             output.push_str(&item?.as_string()?);
         }
 
-        Ok(output)
+        Ok(Spanned { item: output, span })
     }
 }
 impl Debug for RawStream {


### PR DESCRIPTION
# Description

Try out having pipelinedata helpers collect rawstreams before they apply functions. This fixes up `str trim` for me, and might be worth a try for nushell/engine-q#968 and similar.

cc @fdncred 
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
